### PR TITLE
Remove playbar-toggle id from playbar switch

### DIFF
--- a/common/playbar.js
+++ b/common/playbar.js
@@ -21,7 +21,7 @@ $(document).ready(function () {
               <input type="number" id="elevation_max" value=0.5 min=0 step="0.01">
             </span>
             <label class="switch">
-              <input type="checkbox" id="playbar_toggle">
+              <input type="checkbox" >
               <span class="toggleslider" id="toggleslider"></span>
             </label>
             <input type="range" name="playback_speed" id="playback_speed" min="1" max="8" value="4" step="any">


### PR DESCRIPTION
The fastest and most aesthetically pleasing way to fix this bug was to remove the ID on the switch. It's giving the playbar some nice padding and forcing the buttons mostly in line which is good but it's weird to see the whole point cloud turn red if you happen to click it. Removing the id took away the CSS that was causing that effect. Future work to add better styling to the playbar and remove this switch permanently is a good idea.


