### PR TITLE
Merge Feature/annotate segments into develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ libs/CesiumUnminified
 pointclouds/
 develop/clouds
 pointclouds/veritas
-
+data/
 
 # Unwanted Data Filetypes
 *.fb

--- a/common/playbar.js
+++ b/common/playbar.js
@@ -220,8 +220,8 @@ $(document).ready(function () {
 
       // Download Left Lane Vertices:
       try {
-        const laneLeft = window.viewer.scene.scene.getChildByName("Lane Left");
-        download(JSON.stringify(laneLeft.points, null, 2), "lane-left.json");
+        const laneLeft = window.viewer.scene.scene.getChildByName("Left Lane Segments");
+        download(JSON.stringify(laneLeft.getFinalPoints(), null, 2), "lane-left.json");
       } catch (e) {
         console.error("Couldn't download left lane vertices: ", e);
       }
@@ -236,8 +236,8 @@ $(document).ready(function () {
 
       // Download Right Lane Vertices:
       try {
-        const laneRight = window.viewer.scene.scene.getChildByName("Lane Right");
-        download(JSON.stringify(laneRight.points, null, 2), "lane-right.json", "text/plain");
+        const laneRight = window.viewer.scene.scene.getChildByName("Right Lane Segments");
+        download(JSON.stringify(laneRight.getFinalPoints(), null, 2), "lane-right.json", "text/plain");
       } catch (e) {
         console.error("Couldn't download left lane vertices: ", e);
       }

--- a/demo/LaneSegments.js
+++ b/demo/LaneSegments.js
@@ -26,7 +26,7 @@ export class LaneSegments extends THREE.Object3D {
 
 	finalizeSegment() {
 		// add geometry object to this class (each measure object)
-		this.add(measures[measures.length-1]);
+		this.add(this.measures[this.measures.length-1]);
 	}
 
 	incrementOffset(point) {

--- a/demo/LaneSegments.js
+++ b/demo/LaneSegments.js
@@ -1,0 +1,32 @@
+import { Measure } from "../src/utils/Measure.js";
+
+export class LaneSegments {
+	constructor() {
+		this.offsets = [];
+		this.offsets(0)
+		this.measures = [];
+		this.outPoints = [];
+		this.outPoints.push([])
+	}
+
+	initializeSegment(subName) { // have to be a callback?
+		// Right Lane Segment or Left Lane Segment
+		laneSegment = new Measure();
+		laneSegment.name = subName + this.offsets.length.toString();
+		laneSegment.closed = false;
+		laneSegment.showCoordinates = true;
+		laneSegment.showAngles = true;
+
+		this.measures.push(laneSegment);
+		this.offsets.push(0);
+		this.outPoints.push([]);
+	};
+
+	incrementOffset(point) {
+		// increment latest offset and add point to latest outPoints
+	};
+
+	addSegmentMarker(point) {
+		// call addMarker for latest measure object
+	};
+};

--- a/demo/LaneSegments.js
+++ b/demo/LaneSegments.js
@@ -41,13 +41,13 @@ export class LaneSegments extends THREE.Object3D {
 	};
 
 	getFinalPoints() {
-		let finalPoints = [];
+		var finalPoints = [];
 
-		finalPoints.concat(outPoints[0]);
+		finalPoints = finalPoints.concat(this.outPoints[0]);
 
 		for (let si=0, sLen=this.segments.length; si<sLen; si++) {
-			finalPoints.concat(this.segments[si].points);
-			finalPoints.concat(outPoints[si+1]);
+			finalPoints = finalPoints.concat(this.segments[si].points);
+			finalPoints = finalPoints.concat(this.outPoints[si+1]);
 		}
 
 		return finalPoints;

--- a/demo/LaneSegments.js
+++ b/demo/LaneSegments.js
@@ -1,9 +1,11 @@
 import { Measure } from "../src/utils/Measure.js";
 
-export class LaneSegments {
+export class LaneSegments extends THREE.Object3D {
 	constructor() {
+		super()
+
 		this.offsets = [];
-		this.offsets(0)
+		this.offsets.push(0)
 		this.measures = [];
 		this.outPoints = [];
 		this.outPoints.push([])
@@ -11,7 +13,7 @@ export class LaneSegments {
 
 	initializeSegment(subName) { // have to be a callback?
 		// Right Lane Segment or Left Lane Segment
-		laneSegment = new Measure();
+		let laneSegment = new Measure();
 		laneSegment.name = subName + this.offsets.length.toString();
 		laneSegment.closed = false;
 		laneSegment.showCoordinates = true;
@@ -22,11 +24,19 @@ export class LaneSegments {
 		this.outPoints.push([]);
 	};
 
+	finalizeSegment() {
+		// add geometry object to this class (each measure object)
+		this.add(measures[measures.length-1]);
+	}
+
 	incrementOffset(point) {
 		// increment latest offset and add point to latest outPoints
+		this.offsets[this.offsets.length-1] = this.offsets[this.offsets.length-1]+1;
+		this.outPoints[this.outPoints.length-1].push({position: point});
 	};
 
 	addSegmentMarker(point) {
 		// call addMarker for latest measure object
+		this.measures[this.measures.length-1].addMarker(point)
 	};
 };

--- a/demo/LaneSegments.js
+++ b/demo/LaneSegments.js
@@ -6,7 +6,7 @@ export class LaneSegments extends THREE.Object3D {
 
 		this.offsets = [];
 		this.offsets.push(0)
-		this.measures = [];
+		this.segments = [];
 		this.outPoints = [];
 		this.outPoints.push([])
 	}
@@ -19,15 +19,15 @@ export class LaneSegments extends THREE.Object3D {
 		laneSegment.showCoordinates = true;
 		laneSegment.showAngles = true;
 
-		this.measures.push(laneSegment);
+		this.segments.push(laneSegment);
 		this.offsets.push(0);
 		this.outPoints.push([]);
 	};
 
 	finalizeSegment() {
 		// add geometry object to this class (each measure object)
-		this.add(this.measures[this.measures.length-1]);
-	}
+		this.add(this.segments[this.segments.length-1]);
+	};
 
 	incrementOffset(point) {
 		// increment latest offset and add point to latest outPoints
@@ -37,6 +37,19 @@ export class LaneSegments extends THREE.Object3D {
 
 	addSegmentMarker(point) {
 		// call addMarker for latest measure object
-		this.measures[this.measures.length-1].addMarker(point)
+		this.segments[this.segments.length-1].addMarker(point);
+	};
+
+	getFinalPoints() {
+		let finalPoints = [];
+
+		finalPoints.concat(outPoints[0]);
+
+		for (let si=0, sLen=this.segments.length; si<sLen; si++) {
+			finalPoints.concat(this.segments[si].points);
+			finalPoints.concat(outPoints[si+1]);
+		}
+
+		return finalPoints;
 	};
 };

--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -249,8 +249,8 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
   // laneSpine = new Measure(); laneSpine.name = "Lane Spine"; //laneRight.closed = false;
   laneRight = new Measure(); laneRight.name = "Lane Right"; laneRight.closed = false; laneRight.showCoordinates = true; laneRight.showAngles = true;
 
-  let leftLaneSegments = new LaneSegments();
-  let rightLaneSegments = new LaneSegments();
+  var leftLaneSegments = new LaneSegments();
+  var rightLaneSegments = new LaneSegments();
 
   var clonedBoxes = [];
   for (let vi=0, vlen=volumes.length; vi<vlen; vi++) {
@@ -274,29 +274,15 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
     var geometrySpine = new THREE.Geometry();
     var geometryRight = new THREE.Geometry();
 
-    let left, right, spine;
-    let isContains = false;
+    var left, right, spine;
+    var isContains = false;
     for(let jj=0, numVertices=lane.leftLength(); jj<numVertices; jj++) {
       left = lane.left(jj);
 
       if (annotationMode) {
 
-        let newIsContains = false;
-        for (let bbi=0, bbLen=clonedBoxes.length; bbi<bbLen; bbi++) {
-          newIsContains = clonedBoxes[bbi].containsPoint(new THREE.Vector3(left.x(), left.y(), left.z()));
-        }
-        if (newIsContains && !isContains) {
-          leftLaneSegments.initializeSegment("Left Lane Segment ");
-        }
-        isContains = newIsContains;
-
-        if (isContains) {
-          leftLaneSegments.addSegmentMarker(new THREE.Vector3(left.x(), left.y(), left.z()));
-        } else {
-          leftLaneSegments.incrementOffset(new THREE.Vector3(left.x(), left.y(), left.z()));
-        }
-
-        console.log(newIsContains, jj);
+        isContains = updateSegments(leftLaneSegments, clonedBoxes, isContains, left)
+        console.log(isContains, jj);
 
         laneLeft.addMarker(new THREE.Vector3(left.x(), left.y(), left.z()));
       } else {
@@ -310,10 +296,7 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
 
       if (annotationMode) {
 
-        let isContains = false;
-        for (let bbi=0, bbLen=clonedBoxes.length; bbi<bbLen; bbi++) {
-          isContains = clonedBoxes[bbi].containsPoint(new THREE.Vector3(right.x(), right.y(), right.z()));
-        }
+        isContains = updateSegments(rightLaneSegments, clonedBoxes, isContains, right)
         console.log(isContains, jj);
 
         laneRight.addMarker(new THREE.Vector3(right.x(), right.y(), right.z()));
@@ -440,4 +423,26 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
     all: all
   }
   return output;
+}
+
+function updateSegments(laneSegments, clonedBoxes, prevIsContains, point) {
+
+  let newIsContains = false;
+  for (let bbi=0, bbLen=clonedBoxes.length; bbi<bbLen; bbi++) {
+    newIsContains = clonedBoxes[bbi].containsPoint(new THREE.Vector3(point.x(), point.y(), point.z()));
+  }
+  if (newIsContains && !prevIsContains) {
+    laneSegments.initializeSegment("Left Lane Segment ");
+  }
+  if (!newIsContains && prevIsContains) {
+    laneSegments.finalizeSegment();
+  }
+
+  if (newIsContains) {
+    laneSegments.addSegmentMarker(new THREE.Vector3(point.x(), point.y(), point.z()));
+  } else {
+    laneSegments.incrementOffset(new THREE.Vector3(point.x(), point.y(), point.z()));
+  }
+
+  return newIsContains
 }

--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -281,9 +281,11 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
 
       if (annotationMode) {
 
-        isContains = updateSegments(leftLaneSegments, clonedBoxes, isContains, left, jj, numVertices)
-
-        laneLeft.addMarker(new THREE.Vector3(left.x(), left.y(), left.z()));
+        if (volumes.length == 0) {
+          laneLeft.addMarker(new THREE.Vector3(left.x(), left.y(), left.z()));
+        } else {
+          isContains = updateSegments(leftLaneSegments, clonedBoxes, isContains, left, jj, numVertices);
+        }
       } else {
         geometryLeft.vertices.push( new THREE.Vector3(left.x(), left.y(), left.z()));
       }
@@ -295,9 +297,12 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
 
       if (annotationMode) {
 
-        isContains = updateSegments(rightLaneSegments, clonedBoxes, isContains, right, jj, numVertices)
-
-        laneRight.addMarker(new THREE.Vector3(right.x(), right.y(), right.z()));
+        if (volumes.length == 0) {
+          laneRight.addMarker(new THREE.Vector3(right.x(), right.y(), right.z()));
+        }
+        else {
+          isContains = updateSegments(rightLaneSegments, clonedBoxes, isContains, right, jj, numVertices);
+        }
       } else {
         geometryRight.vertices.push( new THREE.Vector3(right.x(), right.y(), right.z()));
       }

--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -282,7 +282,6 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
       if (annotationMode) {
 
         isContains = updateSegments(leftLaneSegments, clonedBoxes, isContains, left, jj, numVertices)
-        console.log(isContains, jj);
 
         laneLeft.addMarker(new THREE.Vector3(left.x(), left.y(), left.z()));
       } else {
@@ -297,7 +296,6 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
       if (annotationMode) {
 
         isContains = updateSegments(rightLaneSegments, clonedBoxes, isContains, right, jj, numVertices)
-        console.log(isContains, jj);
 
         laneRight.addMarker(new THREE.Vector3(right.x(), right.y(), right.z()));
       } else {

--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -249,6 +249,12 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
   // laneSpine = new Measure(); laneSpine.name = "Lane Spine"; //laneRight.closed = false;
   laneRight = new Measure(); laneRight.name = "Lane Right"; laneRight.closed = false; laneRight.showCoordinates = true; laneRight.showAngles = true;
 
+  var clonedBoxes = [];
+  for (let vi=0, vlen=volumes.length; vi<vlen; vi++) {
+    let clonedBbox = volumes[vi].boundingBox.clone();
+    clonedBbox.applyMatrix4(volumes[vi].matrixWorld);
+    clonedBoxes.push(clonedBbox);
+  }
 
   let lane;
   let lefts = [];
@@ -268,6 +274,13 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
       left = lane.left(jj);
 
       if (annotationMode) {
+
+        let isContains = false;
+        for (let bbi=0, bbLen=clonedBoxes.length; bbi<bbLen; bbi++) {
+          isContains = clonedBoxes[bbi].containsPoint(new THREE.Vector3(left.x(), left.y(), left.z()));
+        }
+        console.log(isContains, jj);
+
         laneLeft.addMarker(new THREE.Vector3(left.x(), left.y(), left.z()));
       } else {
         geometryLeft.vertices.push( new THREE.Vector3(left.x(), left.y(), left.z()));
@@ -278,6 +291,13 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
       right = lane.right(jj);
 
       if (annotationMode) {
+
+        let isContains = false;
+        for (let bbi=0, bbLen=clonedBoxes.length; bbi<bbLen; bbi++) {
+          isContains = clonedBoxes[bbi].containsPoint(new THREE.Vector3(right.x(), right.y(), right.z()));
+        }
+        console.log(isContains, jj);
+
         laneRight.addMarker(new THREE.Vector3(right.x(), right.y(), right.z()));
       } else {
         geometryRight.vertices.push( new THREE.Vector3(right.x(), right.y(), right.z()));

--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -274,7 +274,7 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
     var geometrySpine = new THREE.Geometry();
     var geometryRight = new THREE.Geometry();
 
-    var left, right, spine;
+    let left, right, spine;
     var isContains = false;
     for(let jj=0, numVertices=lane.leftLength(); jj<numVertices; jj++) {
       left = lane.left(jj);

--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -414,9 +414,11 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
   }
 
   if (annotationMode) {
-    all.push(laneLeft);
-    // all.push(laneSpine);
-    all.push(laneRight);
+    //all.push(laneLeft);
+    //// all.push(laneSpine);
+    //all.push(laneRight);
+    all.push(leftLaneSegments);
+    all.push(rightLaneSegments);
   }
 
   let output = {
@@ -429,7 +431,10 @@ function updateSegments(laneSegments, clonedBoxes, prevIsContains, point) {
 
   let newIsContains = false;
   for (let bbi=0, bbLen=clonedBoxes.length; bbi<bbLen; bbi++) {
-    newIsContains = clonedBoxes[bbi].containsPoint(new THREE.Vector3(point.x(), point.y(), point.z()));
+    let isContains = clonedBoxes[bbi].containsPoint(new THREE.Vector3(point.x(), point.y(), point.z()));
+    if (isContains) {
+      newIsContains = isContains;
+    }
   }
   if (newIsContains && !prevIsContains) {
     laneSegments.initializeSegment("Left Lane Segment ");

--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -249,10 +249,10 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
   // laneSpine = new Measure(); laneSpine.name = "Lane Spine"; //laneRight.closed = false;
   laneRight = new Measure(); laneRight.name = "Lane Right"; laneRight.closed = false; laneRight.showCoordinates = true; laneRight.showAngles = true;
 
-  var leftLaneSegments = new LaneSegments(); leftLaneSegments.name = "Left Lane Segments";
-  var rightLaneSegments = new LaneSegments(); rightLaneSegments.name = "Right Lane Segments";
+  let leftLaneSegments = new LaneSegments(); leftLaneSegments.name = "Left Lane Segments";
+  let rightLaneSegments = new LaneSegments(); rightLaneSegments.name = "Right Lane Segments";
 
-  var clonedBoxes = [];
+  let clonedBoxes = [];
   for (let vi=0, vlen=volumes.length; vi<vlen; vi++) {
     if (volumes[vi].clip) {
       let clonedBbox = volumes[vi].boundingBox.clone();
@@ -275,7 +275,7 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
     var geometryRight = new THREE.Geometry();
 
     let left, right, spine;
-    var isContains = false;
+    let isContains = false;
     for(let jj=0, numVertices=lane.leftLength(); jj<numVertices; jj++) {
       left = lane.left(jj);
 
@@ -443,7 +443,7 @@ function updateSegments(laneSegments, clonedBoxes, prevIsContains, point, index,
     }
   }
   if (newIsContains && !prevIsContains) {
-    laneSegments.initializeSegment("Left Lane Segment ");
+    laneSegments.initializeSegment("Lane Segment "); // can pass as a parameter and differentiate between left and right, but not required for now
   }
   if (!newIsContains && prevIsContains) {
     laneSegments.finalizeSegment();

--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -249,8 +249,8 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
   // laneSpine = new Measure(); laneSpine.name = "Lane Spine"; //laneRight.closed = false;
   laneRight = new Measure(); laneRight.name = "Lane Right"; laneRight.closed = false; laneRight.showCoordinates = true; laneRight.showAngles = true;
 
-  var leftLaneSegments = new LaneSegments();
-  var rightLaneSegments = new LaneSegments();
+  var leftLaneSegments = new LaneSegments(); leftLaneSegments.name = "Left Lane Segments";
+  var rightLaneSegments = new LaneSegments(); rightLaneSegments.name = "Right Lane Segments";
 
   var clonedBoxes = [];
   for (let vi=0, vlen=volumes.length; vi<vlen; vi++) {
@@ -281,7 +281,7 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
 
       if (annotationMode) {
 
-        isContains = updateSegments(leftLaneSegments, clonedBoxes, isContains, left)
+        isContains = updateSegments(leftLaneSegments, clonedBoxes, isContains, left, jj, numVertices)
         console.log(isContains, jj);
 
         laneLeft.addMarker(new THREE.Vector3(left.x(), left.y(), left.z()));
@@ -296,7 +296,7 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
 
       if (annotationMode) {
 
-        isContains = updateSegments(rightLaneSegments, clonedBoxes, isContains, right)
+        isContains = updateSegments(rightLaneSegments, clonedBoxes, isContains, right, jj, numVertices)
         console.log(isContains, jj);
 
         laneRight.addMarker(new THREE.Vector3(right.x(), right.y(), right.z()));
@@ -427,7 +427,7 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
   return output;
 }
 
-function updateSegments(laneSegments, clonedBoxes, prevIsContains, point) {
+function updateSegments(laneSegments, clonedBoxes, prevIsContains, point, index, lengthArray) {
 
   let newIsContains = false;
   for (let bbi=0, bbLen=clonedBoxes.length; bbi<bbLen; bbi++) {
@@ -447,6 +447,11 @@ function updateSegments(laneSegments, clonedBoxes, prevIsContains, point) {
     laneSegments.addSegmentMarker(new THREE.Vector3(point.x(), point.y(), point.z()));
   } else {
     laneSegments.incrementOffset(new THREE.Vector3(point.x(), point.y(), point.z()));
+  }
+
+  // edge case if a segment exists at the end
+  if (newIsContains && index == lengthArray-1) {
+    laneSegments.finalizeSegment();
   }
 
   return newIsContains

--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -412,11 +412,14 @@ function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
   }
 
   if (annotationMode) {
-    //all.push(laneLeft);
-    //// all.push(laneSpine);
-    //all.push(laneRight);
-    all.push(leftLaneSegments);
-    all.push(rightLaneSegments);
+    if (volumes.length > 0) {
+      all.push(leftLaneSegments);
+      all.push(rightLaneSegments);
+    } else {
+      all.push(laneLeft);
+      // all.push(laneSpine);
+      all.push(laneRight);
+    }
   }
 
   let output = {

--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -2,7 +2,7 @@ import { Measure } from "../src/utils/Measure.js";
 
 
 
-export async function loadLanes(s3, bucket, name, fname, supplierNum, annotationMode, callback) {
+export async function loadLanes(s3, bucket, name, fname, supplierNum, annotationMode, volumes, callback) {
   const tstart = performance.now();
 
   // Logic for dealing with Map Supplier Data:
@@ -34,7 +34,7 @@ export async function loadLanes(s3, bucket, name, fname, supplierNum, annotation
                        console.log(err, err.stack);
                      } else {
                        const FlatbufferModule = await import(schemaUrl);
-                       const laneGeometries = parseLanes(data.Body, FlatbufferModule, resolvedSupplierNum, annotationMode);
+                       const laneGeometries = parseLanes(data.Body, FlatbufferModule, resolvedSupplierNum, annotationMode, volumes);
                        callback( laneGeometries );
                      }});
     })();
@@ -64,7 +64,7 @@ export async function loadLanes(s3, bucket, name, fname, supplierNum, annotation
       }
 
       let bytesArray = new Uint8Array(response);
-      const laneGeometries = parseLanes(bytesArray, FlatbufferModule, resolvedSupplierNum, annotationMode);
+      const laneGeometries = parseLanes(bytesArray, FlatbufferModule, resolvedSupplierNum, annotationMode, volumes);
       callback( laneGeometries );
     };
 
@@ -75,7 +75,7 @@ export async function loadLanes(s3, bucket, name, fname, supplierNum, annotation
 
 
 
-function parseLanes(bytesArray, FlatbufferModule, supplierNum, annotationMode) {
+function parseLanes(bytesArray, FlatbufferModule, supplierNum, annotationMode, volumes) {
 
   let numBytes = bytesArray.length;
   let lanes = [];
@@ -97,7 +97,7 @@ function parseLanes(bytesArray, FlatbufferModule, supplierNum, annotationMode) {
     lanes.push(lane);
     segOffset += segSize;
   }
-  return createLaneGeometriesOld(lanes, supplierNum, annotationMode);
+  return createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes);
 }
 
 
@@ -209,7 +209,7 @@ function createLaneGeometries(vertexGroups, material) {
 }
 
 
-function createLaneGeometriesOld(lanes, supplierNum, annotationMode) {
+function createLaneGeometriesOld(lanes, supplierNum, annotationMode, volumes) {
 
   let materialLeft, materialSpine, materialRight;
   switch (supplierNum) {

--- a/demo/radar.html
+++ b/demo/radar.html
@@ -157,7 +157,7 @@
 		const names = JSON.parse(params.get("names"));
 		const name = params.get("clicked");
 		const visualizationMode = params.get("mode");
-		const annotateLanesAvailable = params.get('annotate') == 'Annotate';
+		const annotateLanesAvailable = true; //params.get('annotate') == 'Annotate';
 		const downloadLanesAvailable = annotateLanesAvailable;
 		const accessKeyId = params.get("key1");
 		const secretAccessKey = params.get("key2");
@@ -775,8 +775,9 @@ $(document).ready(() => {
 
 			let filename, tmpSupplierNum;
 			tmpSupplierNum = -1;
-			await loadLanes(s3, bucket, name, filename, tmpSupplierNum, window.annotateLanesModeActive, (laneGeometries) => {
+			await loadLanes(s3, bucket, name, filename, tmpSupplierNum, window.annotateLanesModeActive, viewer.scene.volumes, (laneGeometries) => {
 
+				// need to have Annoted Lanes layer, so that can have original and edited lanes layers
 				let lanesLayer = new THREE.Group();
 				lanesLayer.name = "Lanes";
 				for (let ii=0, len=laneGeometries.all.length; ii<len; ii++) {
@@ -831,7 +832,7 @@ $(document).ready(() => {
 			if (comparisonDatasets.length > 0) {
 				filename = 'lanes.fb';
 				tmpSupplierNum = -2;
-				await loadLanes(s3, bucket, comparisonDatasets[0], filename, tmpSupplierNum, window.annotateLanesModeActive, (laneGeometries) => {
+				await loadLanes(s3, bucket, comparisonDatasets[0], filename, tmpSupplierNum, window.annotateLanesModeActive, viewer.scene.volumes, (laneGeometries) => {
 
 					let lanesLayer = new THREE.Group();
 					lanesLayer.name = `Lanes-${comparisonDatasets[0].split("Data/")[1]}`;

--- a/demo/radar.html
+++ b/demo/radar.html
@@ -158,7 +158,6 @@
 		const name = params.get("clicked");
 		const visualizationMode = params.get("mode");
 		const annotateLanesAvailable = params.get('annotate') == 'Annotate';
-		// const annotateLanesAvailable = true; //hack to annotate lanes locally
 		const downloadLanesAvailable = annotateLanesAvailable;
 		const accessKeyId = params.get("key1");
 		const secretAccessKey = params.get("key2");

--- a/demo/radar.html
+++ b/demo/radar.html
@@ -157,7 +157,8 @@
 		const names = JSON.parse(params.get("names"));
 		const name = params.get("clicked");
 		const visualizationMode = params.get("mode");
-		const annotateLanesAvailable = true; //params.get('annotate') == 'Annotate';
+		const annotateLanesAvailable = params.get('annotate') == 'Annotate';
+		// const annotateLanesAvailable = true; //hack to annotate lanes locally
 		const downloadLanesAvailable = annotateLanesAvailable;
 		const accessKeyId = params.get("key1");
 		const secretAccessKey = params.get("key2");

--- a/src/utils/Measure.js
+++ b/src/utils/Measure.js
@@ -162,6 +162,7 @@ export class Measure extends THREE.Object3D {
 						for (let key of Object.keys(I.point).filter(e => e !== 'position')) {
 							point[key] = I.point[key];
 						}
+						// this is where attributes other than position is being added (ie. intensity and gpsTime)
 
 						this.setPosition(i, I.location);
 					}


### PR DESCRIPTION
This feature:

 - Enables the annotating of segments if clip volumes exist
   - It finds which lane points exist within the clip volumes, keeps the other points available
   - Pieces all of them together, when having to download lanes
 - Allows for multiple clip volumes
 - Still allows old annotating work flow if there are no clip volumes present


