### PR TITLE
slider improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ scripts/__pycache__/
 # Unwanted Data Filetypes
 *.fb
 *.csv
+
+.idea

--- a/common/playbar.css
+++ b/common/playbar.css
@@ -32,15 +32,28 @@
 
 #value {
   color: #FFFFFF;
+}
+
+.playbar_row {
   font-family: 'Open Sans', sans-serif;
   font-size: 125%;
   display: flex;
   vertical-align: bottom;
 }
 
-.center_column {
+#play_pause_container {
+  flex-grow: 0;
+}
+
+.value_column {
+  flex-grow: 1;
   display: flex;
   align-items: center;
+  justify-content: stretch;
+}
+
+.value_column + .value_column {
+  margin-left: 15px;
 }
 
 .play_pause_button {
@@ -68,8 +81,17 @@
   border: 0px;
 }
 
-.window_header {
+.align_right {
   text-align: right;
+  margin-left: .5em;
+}
+
+#time_display_container {
+  flex-direction: column;
+}
+
+.time_display_section {
+  display: inline;
 }
 
 .window {
@@ -84,18 +106,19 @@
   justify-content: stretch;
 }
 
-.fill_button {
+.box_button {
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
-  height: 100%;
+  width: 100%;
+  height: 32px;
 }
 
-.fill_button:hover {
+.box_button:hover {
   background-color: #FFFFFF;
 }
 
-.fill_button:active {
+.box_button:active {
   background-color: #888888;
 }
 
@@ -117,7 +140,11 @@ input::-webkit-inner-spin-button {
 }
 
 #time_display {
-  width: 125px;
+  width: 5em;
+}
+
+#full_time_display {
+  width: 5em;
 }
 
 #windows {
@@ -147,39 +174,4 @@ input::-webkit-inner-spin-button {
   display: inline;
   width: 50px;
   text-align: center;
-}
-
-/* TOGGLE SWITCH */
-/* The switch - the box around the slider */
-.switch {
- position: relative;
- display: inline-block;
- width: 60px;
- height: 34px;
-}
-
-/* Hide default HTML checkbox */
-.switch input {display:none;}
-
-input:checked + .toggleslider {
- background-color: #2196F3;
-}
-
-input:focus + .toggleslider {
- box-shadow: 0 0 1px #2196F3;
-}
-
-input:checked + .toggleslider:before {
- -webkit-transform: translateX(26px);
- -ms-transform: translateX(26px);
- transform: translateX(26px);
-}
-
-/* Rounded sliders */
-.toggleslider.round {
- border-radius: 34px;
-}
-
-.toggleslider.round:before {
- border-radius: 50%;
 }

--- a/common/playbar.css
+++ b/common/playbar.css
@@ -1,13 +1,11 @@
 .potree_container .overlay {
-    height: 85px;
-    width: 100%;
-    position: absolute;
-    bottom: 0px;
-    left: 0px;
-    z-index: 4;
-    background: #19282C;
-    opacity: 0.5;
-    transition: .2s;
+  width: 100%;
+  position: absolute;
+  bottom: 0px;
+  left: 0px;
+  z-index: 4;
+  background: #19282C;
+  opacity: 0.5;
 }
 
 .potree_container .overlay:hover {
@@ -16,79 +14,36 @@
 }
 
 .slidecontainer {
-    width: 100%;
+  width: 100%;
 }
 
 .slider {
-    -webkit-appearance: none;
-    width: 99%;
-    padding-right: 10px;
-    height: 25px;
-    background: #19282c;
-    outline: none;
-    opacity: 0.7;
-    -webkit-transition: .2s;
-    transition: opacity .2s;
+  width: 100%;
+  background: #19282c;
+  margin: 8px;
+  opacity: 1;
 }
 
-.slider:hover {
-    opacity: 1;
-}
-
-.slider::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    width: 10px;
-    height: 10px;
-    background: #FF0000;
-    cursor: pointer;
-    transition: .2s;
-}
-.slider::-webkit-slider-thumb:hover {
-  width: 15px;
-  height: 15px;
-}
-.slider::-webkit-slider-runnable-track {
-  -webkit-appearance: none;
-  background: #FFFFFF;
-  /* width: 100%; */
-  /* height: 5px;  */
-}
-
-.slider::-moz-range-thumb {
-    width: 10px;
-    height: 10px;
-    border: 0;
-    background: #FF0000;
-    cursor: pointer;
-    transition: .2s;
-}
-.slider::-moz-range-thumb:hover {
-  width: 15px;
-  height: 15px;
-}
-.slider::-moz-range-progress {
-  background-color: #FF0000;
-}
-.slider::-moz-range-track {
-  background-color: #FFFFFF;
+.slider > .ui-slider-handle {
+  z-index: 1;
+  background: #FF0000;
+  cursor: pointer;
 }
 
 #value {
   color: #FFFFFF;
-  top: 0px;
-  /* padding-top: 10px; */
-  /* padding-bottom: 5px; */
   font-family: 'Open Sans', sans-serif;
-  font-size: 125%
+  font-size: 125%;
+  display: flex;
+  vertical-align: bottom;
 }
 
-.inline {
-   display:inline-flex;
-   /* margin-right:5px; */
-   vertical-align: bottom;
+.center_column {
+  display: flex;
+  align-items: center;
 }
 
-.button {
+.play_pause_button {
   color: #FFFFFF;
   outline: 0;
   background: none;
@@ -96,26 +51,52 @@
   height: 25px;
   opacity: 0.7;
 }
-.button:active {
+
+.play_pause_button:active {
   color: #FF0000;
   opacity: 1.0;
   outline: 0;
 }
-.button:hover {
+
+.play_pause_button:hover {
   color: #FFFFFF;
   opacity: 1.0;
   outline: 0;
 }
-.button::-mos-focus-inner {
+
+.play_pause_button::-mos-focus-inner {
   border: 0px;
 }
 
-#toggleplay {
-  display: none;
+.window_header {
+  text-align: right;
 }
 
-#pausebutton {
-  display: none;
+.window {
+  width: 150px;
+}
+
+.button_column {
+  width: 125px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: stretch;
+}
+
+.fill_button {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  height: 100%;
+}
+
+.fill_button:hover {
+  background-color: #FFFFFF;
+}
+
+.fill_button:active {
+  background-color: #888888;
 }
 
 input[type="number"] {
@@ -127,11 +108,7 @@ input::-webkit-inner-spin-button {
   -webkit-appearance: none;
 }
 
-#play_pause_table {
-  padding-top: 5px;
-}
-
-#time_display, #playbar_tmin, #playbar_tmax, #elevation_min, #elevation_max {
+.playbar_text_field {
   background: none;
   border: none;
   color: white;
@@ -183,31 +160,6 @@ input::-webkit-inner-spin-button {
 
 /* Hide default HTML checkbox */
 .switch input {display:none;}
-
-/* The slider */
-.toggleslider {
- position: absolute;
- cursor: pointer;
- top: 0;
- left: 0;
- right: 0;
- bottom: 0;
- background-color: #ccc;
- -webkit-transition: .4s;
- transition: .4s;
-}
-
-.toggleslider:before {
- position: absolute;
- content: "";
- height: 26px;
- width: 26px;
- left: 4px;
- bottom: 4px;
- background-color: white;
- -webkit-transition: .4s;
- transition: .4s;
-}
 
 input:checked + .toggleslider {
  background-color: #2196F3;

--- a/common/playbar.js
+++ b/common/playbar.js
@@ -4,46 +4,45 @@ $(document).ready(function () {
   var playbarhtml = $(`
     <div class="overlay">
       <div class="slidecontainer">
-        <input type="range" min="0" max="100" value=0 step="any" class="slider" id="myRange">
-        <div id="spacer">
+        <div class="slider" id="timeSlider"></div>
+        <div class="slider" id="intervalSlider"></div>
+      </div>
+      <div id="spacer"></div>
 
-          <div id="value" class="inline">
+      <div id="value">
+        <div class="center_column">
+          <button class="play_pause_button" class="play" id="playbutton"><i class="material-icons">play_arrow</i></button>
+          <button class="play_pause_button" class="pause" id="pausebutton" style="display: none"><i class="material-icons">pause</i></button>
+        </div>
+        <div class="center_column">
+          <span id='time_display_span'>Time (s): <input type="number" id="time_display" class="playbar_text_field" min=0 value=0 step="0.0001" /> (<input type="number" id="full_time_display" class="playbar_text_field" min=0 value=0 step="0.0001" readonly/> global)</span>
+        </div>
 
-            <table id='play_pause_table'>
-              <tr>
-                <td><input type="checkbox" id="toggleplay">
-                <button class="button" class="play" id="playbutton" class="inline"><i class="material-icons">play_arrow</i></button>
-                <button class="button" class="pause" id="pausebutton"><i class="material-icons">pause</i></button></td>
-                <td><span id='time_display_span'> Time (seconds): <input type="number" id="time_display" min=0 value=0 step="0.0001"> </span></td>
-              </tr>
-            </table>
+        <table id="windows" class="center_column">
+          <tr>
+            <td class="window_header">Time:</td>
+            <td class="window">[<input type="number" id="playbar_tmin" class="playbar_text_field" value=-0.05 max=0 step="0.01">, <input type="number" id="playbar_tmax" class="playbar_text_field" value=0.05 min=0 step="0.01">]</td>
+            <td>(s)</td>
+          </tr>
+          <tr>
+            <td class="window_header">Elevation:</td>
+            <td class="window">[<input type="number" id="elevation_min" class="playbar_text_field" value=-0.5 max=0 step="0.01">, <input type="number" id="elevation_max" class="playbar_text_field" value=0.5 min=0 step="0.01">]</td>
+            <td>(m)</td>
+          </tr>
+        </table>
 
-            <table id="windows">
-              <tr>
-                <td style="text-align:right">Time Window:</td>
-                <td>[<input type="number" id="playbar_tmin" value=-0.05 max=0 step="0.01">, <input type="number" id="playbar_tmax" value=0.05 min=0 step="0.01">]</td>
-                <td>(s)</td>
-              </tr>
-              <tr>
-                <td style="text-align:right">Elevation Window:</td>
-                <td>[<input type="number" id="elevation_min" value=-0.5 max=0 step="0.01">, <input type="number" id="elevation_max" value=0.5 min=0 step="0.01">]</td>
-                <td>(m)</td>
-              </tr>
-            </table>
-
-            <label class="switch">
-              <input type="checkbox" >
-              <span class="toggleslider" id="toggleslider"></span>
-            </label>
-            <input type="range" name="playback_speed" id="playback_speed" min="1" max="8" value="4" step="any">
-            <button name="toggle_calibration_panels" id="toggle_calibration_panels">Toggle Calibration Panels</button>
-            <button name="toggle_hideshow" id="toggle_hideshow">Toggle Pointcloud Highlight Mode</button>
-            <button name="load_detections_button" id="load_detections_button">Load Detections</button>
-            <button name="load_gaps_button" id="load_gaps_button">Load Gaps</button>
-            <button name="load_radar_button" id="load_radar_button">Load Radar</button>
-            <button name="download_lanes_button" id="download_lanes_button">Download Lanes</button>
-            <button name="reload_lanes_button" id="reload_lanes_button">Annotate Lanes</button>
-          </div>
+        <div class="button_column">
+          <button class="fill_button" name="toggle_calibration_panels" id="toggle_calibration_panels">Toggle Calibration Panels</button>
+          <button class="fill_button" name="toggle_hideshow" id="toggle_hideshow">Toggle Pointcloud Highlight Mode</button>
+        </div>
+        <div class="button_column">
+          <button class="fill_button" name="load_detections_button" id="load_detections_button">Load Detections</button>
+          <button class="fill_button" name="load_gaps_button" id="load_gaps_button">Load Gaps</button>
+          <button class="fill_button" name="load_radar_button" id="load_radar_button">Load Radar</button>
+        </div>
+        <div class="button_column">
+          <button class="fill_button" name="download_lanes_button" id="download_lanes_button">Download Lanes</button>
+          <button class="fill_button" name="reload_lanes_button" id="reload_lanes_button">Annotate Lanes</button>
         </div>
       </div>
     </div>
@@ -65,23 +64,22 @@ $(document).ready(function () {
         $( "#playbar_tmax" ).prop( "disabled", true ); //Disable
 
       } else {
-        $( "#playbar_tmin" ).prop( "disabled", false ); //Enable
-        $( "#playbar_tmax" ).prop( "disabled", false ); //Enable
+        $("#playbar_tmin").prop("disabled", false) //Enable
+        $("#playbar_tmax").prop("disabled", false) //Enable
 
-        var sliderVal = $("#myRange").val() / 100.;
-        var t = sliderVal * lidarRange + lidarOffset;
-        $("#demo").html((t-lidarOffset).toFixed(4));
+        var t = $("#timeSlider").val()
+        $("#demo").html((t - lidarOffset).toFixed(4))
 
         // var dtMin = Number($("#playbar_tmin").val());
         // var dtMax = Number($("#playbar_tmax").val());
 
-        const dtMin = window.animationEngine.activeWindow.backward;
-        const dtMax = window.animationEngine.activeWindow.forward;
+        const dtMin = window.animationEngine.activeWindow.backward
+        const dtMax = window.animationEngine.activeWindow.forward
 
-        tmin = t - dtMin;
-        tmax = t + dtMax;
+        tmin = t - dtMin
+        tmax = t + dtMax
 
-        window.viewer.setFilterGPSTimeRange(tmin, tmax);
+        window.viewer.setFilterGPSTimeRange(tmin, tmax)
       }
     }
 
@@ -89,116 +87,71 @@ $(document).ready(function () {
     function updateSlider(slideval=null) {
 
       if (slideval) {
-        var slider = playbarhtml.find("#myRange");
-        slider.val(slideval);
+        var slider = playbarhtml.find("#timeSlider")
+        slider.val(slideval)
       }
 
-      updateClip();
+      updateClip()
 
     }
 
-    playbarhtml.find("#playbar_tmin").on('input', function() {
-      const tmin = playbarhtml.find("#playbar_tmin");
-      window.animationEngine.activeWindow.backward = Math.abs(Number(tmin.val()));
-      updateClip();
-      window.animationEngine.updateTimeForAll();
-    });
+  playbarhtml.find("#playbar_tmin").on('input', function () {
+    const tmin = playbarhtml.find("#playbar_tmin")
+    window.animationEngine.activeWindow.backward = Math.abs(Number(tmin.val()))
+    updateClip()
+    window.animationEngine.updateTimeForAll()
+  })
 
-    playbarhtml.find("#playbar_tmax").on('input', function() {
-      const tmax = playbarhtml.find("#playbar_tmax");
-      window.animationEngine.activeWindow.forward = Math.abs(Number(tmax.val()));
-      updateClip();
-      window.animationEngine.updateTimeForAll();
-    });
+  playbarhtml.find("#playbar_tmax").on('input', function () {
+    const tmax = playbarhtml.find("#playbar_tmax")
+    window.animationEngine.activeWindow.forward = Math.abs(Number(tmax.val()))
+    updateClip()
+    window.animationEngine.updateTimeForAll()
+  })
 
-    playbarhtml.find("#elevation_max").on('input', function() {
-      const elevationMax = playbarhtml.find("#elevation_max");
-      window.elevationWindow[1] = Math.abs(Number(elevationMax.val()));
-    });
+  playbarhtml.find("#elevation_max").on('input', function () {
+    const elevationMax = playbarhtml.find("#elevation_max")
+    window.elevationWindow[1] = Math.abs(Number(elevationMax.val()))
+  })
 
-    playbarhtml.find("#elevation_min").on('input', function() {
-      const elevationMin = playbarhtml.find("#elevation_min");
-      window.elevationWindow[0] = Math.abs(Number(elevationMin.val()));
-    });
+  playbarhtml.find("#elevation_min").on('input', function () {
+    const elevationMin = playbarhtml.find("#elevation_min")
+    window.elevationWindow[0] = Math.abs(Number(elevationMin.val()))
+  })
 
-    playbarhtml.find("#myRange").on('input', function() {
-      updateSlider();
-    });
+  playbarhtml.find("#playbar_toggle").click(function () {
+    updateClip(disable = this.checked)
+  })
+  playbarhtml.find("#playbar_toggle").trigger('click')
 
-    playbarhtml.find("#myRange").on('wheel', function(e) {
-      var slider = playbarhtml.find("#myRange");
-      // var tmin = playbarhtml.find("#playbar_tmin");
-      // var tmax = playbarhtml.find("#playbar_tmax");
-      var slideval = Number(slider.val());
-      var dy = e.originalEvent.deltaY;
+  playbarhtml.find("#playbutton").mousedown(function () {
+    playbarhtml.find("#playbutton").hide()
+    playbarhtml.find("#pausebutton").show()
 
-      const tmin = window.animationEngine.activeWindow.backward;
-      const tmax = window.animationEngine.activeWindow.forward;
+  })
 
-      var scalefactor = 1;
-      if (e.originalEvent.shiftKey) {
-        scalefactor = 100;
+  playbarhtml.find("#pausebutton").mousedown(function () {
+    playbarhtml.find("#playbutton").show()
+    playbarhtml.find("#pausebutton").hide()
+
+  })
+
+  playbarhtml.find("#toggle_calibration_panels").mouseup(function () {
+
+    // Find Calibration Panels:
+    let panels = $(".draggable-overlay")
+    for (ii = 0, len = panels.length; ii < len; ii++) {
+
+      let panel = panels[ii]
+
+      // Check is visible and toggle:
+      if (panel.style.display == "none" || panel.style.display == "") {
+        panel.style.display = "block"
+      } else {
+        panel.style.display = "none"
       }
 
-      var lidarRange = 1;
-      try {
-       // lidarRange = window.viewer.scene.pointclouds[0].pcoGeometry.nodes.r.gpsTime.range;
-       lidarRange = window.animationEngine.timeRange;
-     } catch (e) {
-     }
-      var stepY = 0;
-      if (dy < 0) {
-        // dt = Number(tmax.val());
-        dt = tmax;
-      } else if (dy > 0) {
-        // dt = Number(tmin.val());
-        dt = -tmin;
-      }
-      dt = dt*scalefactor;
-      var sliderange = Number(slider.attr("max")) - Number(slider.attr("min"));
-      var stepY = sliderange*dt/lidarRange;
-
-      slideval += stepY;
-
-      updateSlider(slideval);
-    });
-    playbarhtml.find("#myRange").on("scroll", function(e) {
-      console.log(e);
-    });
-
-    playbarhtml.find("#playbar_toggle").click(function() {
-      updateClip(disable=this.checked);
-    });
-    playbarhtml.find("#playbar_toggle").trigger('click');
-
-    playbarhtml.find("#playbutton").mousedown(function() {
-      playbarhtml.find("#playbutton").hide();
-      playbarhtml.find("#pausebutton").show();
-
-    });
-
-    playbarhtml.find("#pausebutton").mousedown(function() {
-      playbarhtml.find("#playbutton").show();
-      playbarhtml.find("#pausebutton").hide();
-
-    });
-
-    playbarhtml.find("#toggle_calibration_panels").mouseup(function() {
-
-      // Find Calibration Panels:
-      let panels = $(".draggable-overlay");
-      for(ii=0, len=panels.length; ii<len; ii++) {
-
-        let panel = panels[ii];
-
-        // Check is visible and toggle:
-        if (panel.style.display == "none" || panel.style.display == "") {
-          panel.style.display = "block";
-        } else {
-          panel.style.display = "none"
-        }
-
-      }
+    }
 
     });
 
@@ -283,8 +236,6 @@ $(document).ready(function () {
     // document.getElementById("playbar_tmax").style.display = "none";
     // document.getElementById("elevation_max").style.display = "none";
     // document.getElementById("elevation_min").style.display = "none";
-    document.getElementById("playback_speed").style.display = "none";
-    document.getElementById("toggleslider").style.display = "none";
     // document.getElementById("toggle_calibration_panels").style.display = "none";
     document.getElementById("load_detections_button").style.display = "none";
     document.getElementById("load_gaps_button").style.display = "none";

--- a/common/playbar.js
+++ b/common/playbar.js
@@ -9,41 +9,39 @@ $(document).ready(function () {
       </div>
       <div id="spacer"></div>
 
-      <div id="value">
-        <div class="center_column">
+      <div id="value" class="playbar_row">
+        <div id="play_pause_container" class="value_column">
           <button class="play_pause_button" class="play" id="playbutton"><i class="material-icons">play_arrow</i></button>
           <button class="play_pause_button" class="pause" id="pausebutton" style="display: none"><i class="material-icons">pause</i></button>
         </div>
-        <div class="center_column">
-          <span id='time_display_span'>Time (s): <input type="number" id="time_display" class="playbar_text_field" min=0 value=0 step="0.0001" /> (<input type="number" id="full_time_display" class="playbar_text_field" min=0 value=0 step="0.0001" readonly/> global)</span>
+        
+        <div id="time_display_container" class="value_column">
+          <div class="time_display_section">Time (region): <input type="number" id="time_display" class="playbar_text_field" min=0 value=0 step="0.0001" /> (s)</div>
+          <div class="time_display_section">Time (global): <input type="number" id="full_time_display" class="playbar_text_field" min=0 value=0 step="0.0001" readonly/> (s)</div>
         </div>
 
-        <table id="windows" class="center_column">
+        <table id="windows" class="value_column">
           <tr>
-            <td class="window_header">Time:</td>
+            <td class="align_right">Time Window:</td>
             <td class="window">[<input type="number" id="playbar_tmin" class="playbar_text_field" value=-0.05 max=0 step="0.01">, <input type="number" id="playbar_tmax" class="playbar_text_field" value=0.05 min=0 step="0.01">]</td>
             <td>(s)</td>
           </tr>
           <tr>
-            <td class="window_header">Elevation:</td>
+            <td class="align_right">Elevation Window:</td>
             <td class="window">[<input type="number" id="elevation_min" class="playbar_text_field" value=-0.5 max=0 step="0.01">, <input type="number" id="elevation_max" class="playbar_text_field" value=0.5 min=0 step="0.01">]</td>
             <td>(m)</td>
           </tr>
         </table>
+      </div>
 
-        <div class="button_column">
-          <button class="fill_button" name="toggle_calibration_panels" id="toggle_calibration_panels">Toggle Calibration Panels</button>
-          <button class="fill_button" name="toggle_hideshow" id="toggle_hideshow">Toggle Pointcloud Highlight Mode</button>
-        </div>
-        <div class="button_column">
-          <button class="fill_button" name="load_detections_button" id="load_detections_button">Load Detections</button>
-          <button class="fill_button" name="load_gaps_button" id="load_gaps_button">Load Gaps</button>
-          <button class="fill_button" name="load_radar_button" id="load_radar_button">Load Radar</button>
-        </div>
-        <div class="button_column">
-          <button class="fill_button" name="download_lanes_button" id="download_lanes_button">Download Lanes</button>
-          <button class="fill_button" name="reload_lanes_button" id="reload_lanes_button">Annotate Lanes</button>
-        </div>
+      <div class="playbar_row">
+        <button class="box_button" name="toggle_calibration_panels" id="toggle_calibration_panels">Toggle Calibration Panels</button>
+        <button class="box_button" name="toggle_hideshow" id="toggle_hideshow">Toggle Pointcloud Highlight Mode</button>
+        <button class="box_button" name="load_detections_button" id="load_detections_button">Load Detections</button>
+        <button class="box_button" name="load_gaps_button" id="load_gaps_button">Load Gaps</button>
+        <button class="box_button" name="load_radar_button" id="load_radar_button">Load Radar</button>
+        <button class="box_button" name="download_lanes_button" id="download_lanes_button">Download Lanes</button>
+        <button class="box_button" name="reload_lanes_button" id="reload_lanes_button">Annotate Lanes</button>
       </div>
     </div>
     `);

--- a/demo/animationEngine.js
+++ b/demo/animationEngine.js
@@ -68,11 +68,10 @@ class AnimationEngine {
     this.tweenEngine.update(t);
   }
 
-  updateTimeForAll(t) {
-
+  updateTimeForAll() {
     // Update all targets with current time
-    for(let ii=0, len=this.tweenTargets.length; ii<len; ii++) {
-      this.tweenTargets[ii](this.timeline.t);
+    for (let ii = 0, len = this.tweenTargets.length; ii < len; ii++) {
+      this.tweenTargets[ii](this.timeline.t)
     }
   }
 }

--- a/demo/radar.html
+++ b/demo/radar.html
@@ -156,7 +156,11 @@
 		import {setLoadingScreen, removeLoadingScreen} from "../common/overlay.js"
 		import {PointAttributeNames} from "../src/loader/PointAttributes.js"
 
-		function decanonicalizeTimeInterval({start, end}) {
+		function canonicalizeTimeInterval({start, end}) {
+			return [String(start), String(end)]
+		}
+
+		function decanonicalizeTimeInterval([start, end]) {
 			if (start === "" && end === "") {
 				return null
 			} else {
@@ -180,9 +184,8 @@
 		const downloadLanesAvailable = annotateLanesAvailable
 		const calibrationModeAvailable = params.get("calibrate") == "Calibrate" ||
 				runForLocalDevelopment
-		let customTimeInterval = decanonicalizeTimeInterval({
-			start: params.get("start"), end: params.get("end")
-		})
+		let customTimeInterval = decanonicalizeTimeInterval(
+				[params.get("start"), params.get("end")])
 		const accessKeyId = params.get("key1")
 		const secretAccessKey = params.get("key2")
 		const sessionToken = params.get("key3")
@@ -279,85 +282,92 @@
 
 			// Check if Classification Attribute is exists in PointCloud:
 			try {
-				let pointcloud = viewer.scene.pointclouds[0];
-				togglePointClass(pointcloud);
+				let pointcloud = viewer.scene.pointclouds[0]
+				togglePointClass(pointcloud)
 			} catch (e) {
-				console.log("Sidebar initialized pointcloud loaded: ",e);
+				console.log("Sidebar initialized pointcloud loaded: ", e)
 			}
 		});
 
 		// Create AnimationEngine:
-		window.animationEngine = new AnimationEngine();
+		window.animationEngine = new AnimationEngine()
 
 		// TODO put these material definitions somewhere better
 		let uniforms = {
-					color: { value: new THREE.Color( 0x00ff00 ) },
-					minGpsTime: {value: 0.0 },
-					maxGpsTime: {value: 0.5 },
-					initialTime: {value: 0}, // TODO not used
-					// offset: {value: new THREE.Vector3(0,0,0)}
-			};
-		let shaderMaterial = new THREE.ShaderMaterial( {
+			color: {value: new THREE.Color(0x00ff00)},
+			minGpsTime: {value: 0.0},
+			maxGpsTime: {value: 0.5},
+			initialTime: {value: 0} // TODO not used
+			// offset: {value: new THREE.Vector3(0,0,0)}
+		}
+		let shaderMaterial = new THREE.ShaderMaterial({
 
-				 uniforms:       uniforms,
-				 vertexShader:   document.getElementById( 'vertexshader' ).textContent,
-				 fragmentShader: document.getElementById( 'fragmentshader' ).textContent,
-				 transparent:    true,
-				 depthWrite: 		 false
+			uniforms: uniforms,
+			vertexShader: document.getElementById('vertexshader').textContent,
+			fragmentShader: document.getElementById('fragmentshader').textContent,
+			transparent: true,
+			depthWrite: false
 
-		 });
+		})
+
+		let isShiftKeyDown = false
 
 		// Playbar Configuration:
 		$(document).ready(() => {
-			document.getElementById("playbar_tmax").disabled = false;
-			document.getElementById("playbar_tmin").disabled = false;
-			document.getElementById("elevation_max").display = false;
-			document.getElementById("elevation_min").disabled = false;
+			document.getElementById("playbar_tmax").disabled = false
+			document.getElementById("playbar_tmin").disabled = false
+			document.getElementById("elevation_max").display = false
+			document.getElementById("elevation_min").disabled = false
 
-			window.truthAnnotationMode = 0;	// 0: None, 1: Delete, 2: Add
-			let annotationScreen = $(`<div id="annotationScreen"><p id="annotation-label">ANNOTATION MODE: <b id="annotation-mode-text"></b></p></div>`);
-			$('body').prepend(annotationScreen);
-			let div = document.getElementById("annotationScreen");
-			div.style.opacity=0;
-
+			window.truthAnnotationMode = 0	// 0: None, 1: Delete, 2: Add
+			let annotationScreen = $(
+					`<div id="annotationScreen"><p id="annotation-label">ANNOTATION MODE: <b id="annotation-mode-text"></b></p></div>`)
+			$('body').prepend(annotationScreen)
+			let div = document.getElementById("annotationScreen")
+			div.style.opacity = 0
 
 			window.addEventListener('keydown', (e) => {
+				if (e.shiftKey) {
+					isShiftKeyDown = true
+				}
 				if (window.annotateLanesModeActive) {
 					if (e.code == "KeyA") {
-						window.truthAnnotationMode = 2;
+						window.truthAnnotationMode = 2
 					} else if (e.code == "KeyS") {
-						window.truthAnnotationMode = 1;
+						window.truthAnnotationMode = 1
 					} else if (e.shiftKey) {
-						window.truthAnnotationMode = (window.truthAnnotationMode + 1) % 3;
+						window.truthAnnotationMode = (window.truthAnnotationMode + 1) % 3
 					}
 
-					let div = document.getElementById("annotationScreen");
-					let label = document.getElementById("annotation-mode-text");
+					let div = document.getElementById("annotationScreen")
+					let label = document.getElementById("annotation-mode-text")
 					if (window.truthAnnotationMode == 0) {
-						div.style.background = "black";
-						div.style.opacity=0;
-						label.innerHTML = "NONE";
-					}
-					else if (window.truthAnnotationMode == 1) {
-						div.style.background = "red";
-						div.style.opacity=0.25;
-						label.innerHTML = "DELETE POINTS";
+						div.style.background = "black"
+						div.style.opacity = 0
+						label.innerHTML = "NONE"
+					} else if (window.truthAnnotationMode == 1) {
+						div.style.background = "red"
+						div.style.opacity = 0.25
+						label.innerHTML = "DELETE POINTS"
 					} else if (window.truthAnnotationMode == 2) {
-						div.style.background = "green";
-						div.style.opacity=0.25;
-						label.innerHTML = "ADD POINTS";
+						div.style.background = "green"
+						div.style.opacity = 0.25
+						label.innerHTML = "ADD POINTS"
 					}
 				}
 			});
 
 			window.addEventListener("keyup", (e) => {
+				if (e.shiftKey) {
+					isShiftKeyDown = false
+				}
 				if (window.annotateLanesModeActive) {
-					window.truthAnnotationMode = 0;
-					let div = document.getElementById("annotationScreen");
-					let label = document.getElementById("annotation-mode-text");
-					div.style.background = "black";
-					div.style.opacity=0;
-					label.innerHTML = "NONE";
+					window.truthAnnotationMode = 0
+					let div = document.getElementById("annotationScreen")
+					let label = document.getElementById("annotation-mode-text")
+					div.style.background = "black"
+					div.style.opacity = 0
+					label.innerHTML = "NONE"
 				}
 			});
 
@@ -442,13 +452,12 @@
 
 		window.addEventListener("message", ({data}) => {
 			if (data.type === "updateTimeInterval") {
-				const {start, end} = data
-				customTimeInterval = decanonicalizeTimeInterval({start, end})
+				customTimeInterval = decanonicalizeTimeInterval(data.timeInterval)
 				relaunchAnimationWithNewInterval()
 			}
 		}, false)
 
-		function relaunchAnimationWithNewInterval() {
+		function launchAnimationWithNewInterval() {
 			const tstart = customTimeInterval ?
 					(window.fullTimeInterval.start + customTimeInterval.start) :
 					window.fullTimeInterval.start
@@ -458,6 +467,11 @@
 			const playbackRate = 1.0
 			animationEngine.configure(tstart, tend, playbackRate)
 			animationEngine.launch()
+		}
+
+		function relaunchAnimationWithNewInterval() {
+			launchAnimationWithNewInterval()
+			animationEngine.updateTimeForAll()
 		}
 
 		// Load RTK: TODO REFACTOR THIS (a lot of stuff happening here, break it up if possible)
@@ -470,7 +484,7 @@
 						}
 
 						// TODO Move this into main loader function:
-						relaunchAnimationWithNewInterval()
+						launchAnimationWithNewInterval()
 
 						if (callback) {
 							callback()
@@ -641,7 +655,6 @@
 							animationEngine.start();
 	          });
 
-
 						time_display.addEventListener('keyup', function onEvent(e) {
 					    if (e.keyCode === 13) {
 					        console.log('Enter')
@@ -662,24 +675,54 @@
 						});
 
 						slider.addEventListener("wheel", () => {
-							animationEngine.stop();
-							var val = slider.value/100.0;
-							animationEngine.timeline.t = val*animationEngine.timeRange + animationEngine.tstart;
-							animationEngine.updateTimeForAll();
+							animationEngine.stop()
+							var val = slider.value / 100.0
+							animationEngine.timeline.t =
+									val * animationEngine.timeRange + animationEngine.tstart
+							animationEngine.updateTimeForAll()
 						});
 
 						zmin.addEventListener("input", () => {
-							window.elevationWindow.min = Math.abs(Number(zmin.value));
-							window.elevationWindow.max = Math.abs(Number(zmax.value));
-							animationEngine.updateTimeForAll();
-						});
+							window.elevationWindow.min = Math.abs(Number(zmin.value))
+							window.elevationWindow.max = Math.abs(Number(zmax.value))
+							animationEngine.updateTimeForAll()
+						})
 
-						zmax.addEventListener("input", ()=> {
-							window.elevationWindow.min = Math.abs(Number(zmin.value));
-							window.elevationWindow.max = Math.abs(Number(zmax.value));
-							animationEngine.updateTimeForAll();
-						});
-	        }
+						zmax.addEventListener("input", () => {
+							window.elevationWindow.min = Math.abs(Number(zmin.value))
+							window.elevationWindow.max = Math.abs(Number(zmax.value))
+							animationEngine.updateTimeForAll()
+						})
+
+						// Adjust time interval by shift-clicking and dragging a range
+						function getSliderTimeForInterval() {
+							return (slider.value / 100.0 * animationEngine.timeRange) +
+									animationEngine.tstart - window.fullTimeInterval.start
+						}
+
+						let newTimeIntervalStart = null
+
+						slider.addEventListener("mousedown", () => {
+							if (isShiftKeyDown) {
+								newTimeIntervalStart = getSliderTimeForInterval()
+							}
+						})
+
+						slider.addEventListener("mouseup", () => {
+							if (isShiftKeyDown && newTimeIntervalStart) {
+								const newTimeIntervalEnd = getSliderTimeForInterval()
+								customTimeInterval =
+										{start: newTimeIntervalStart, end: newTimeIntervalEnd}
+								window.parent.postMessage({
+									type: "updateTimeInterval",
+									timeInterval: canonicalizeTimeInterval(customTimeInterval)
+								}, "*")
+								relaunchAnimationWithNewInterval()
+							} else {
+								newTimeIntervalStart = null
+							}
+						})
+					}
 
 	      }
 	    });

--- a/demo/radar.html
+++ b/demo/radar.html
@@ -137,60 +137,77 @@
 
 
 	<script type="module">
-		"use strict";
-		import { loadLanes } from "../demo/laneLoader.js";
-		import { loadTracks } from "../demo/trackLoader.js";
-		import { loadDetections } from "../demo/detectionLoader.js";
-		import { loadRtk, applyRotation } from "../demo/rtkLoader.js";
-		import { loadRtkFlatbuffer } from "../demo/rtkLoaderFlatbuffer.js";
-		import { RtkTrajectory } from "../demo/RtkTrajectory.js";
-		import { loadRadar } from "../demo/radarLoader.js";
-		import { loadGaps } from "../demo/gapsLoader.js";
-		import { loadRem } from "../demo/remLoader.js";
-		import { loadVelo2Rtk, loadRtk2Vehicle, storeCalibration } from "../demo/calibrationManager.js";
-		import { updateSidebar, togglePointClass } from "../common/custom-sidebar.js";
-		import { getLoadingBar } from "../common/overlay.js";
+		"use strict"
+		import {loadLanes} from "../demo/laneLoader.js"
+		import {loadTracks} from "../demo/trackLoader.js"
+		import {loadDetections} from "../demo/detectionLoader.js"
+		import {loadRtk, applyRotation} from "../demo/rtkLoader.js"
+		import {loadRtkFlatbuffer} from "../demo/rtkLoaderFlatbuffer.js"
+		import {RtkTrajectory} from "../demo/RtkTrajectory.js"
+		import {loadRadar} from "../demo/radarLoader.js"
+		import {loadGaps} from "../demo/gapsLoader.js"
+		import {loadRem} from "../demo/remLoader.js"
+		import {
+			loadVelo2Rtk, loadRtk2Vehicle, storeCalibration
+		} from "../demo/calibrationManager.js"
+		import {updateSidebar, togglePointClass} from "../common/custom-sidebar.js"
+		import {getLoadingBar} from "../common/overlay.js"
 		// import {  } from "../common/overlay.js";
-		import { setLoadingScreen, removeLoadingScreen } from "../common/overlay.js";
-		import { PointAttributeNames } from "../src/loader/PointAttributes.js";
+		import {setLoadingScreen, removeLoadingScreen} from "../common/overlay.js"
+		import {PointAttributeNames} from "../src/loader/PointAttributes.js"
+
+		function decanonicalizeTimeInterval({start, end}) {
+			if (start === "" && end === "") {
+				return null
+			} else {
+				return {start: Number(start), end: Number(end)}
+			}
+		}
 
 		// setLoadingScreen();
 
-		const runForLocalDevelopment = location.search === "" && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
+		const runForLocalDevelopment = location.search === "" &&
+				(window.location.hostname === 'localhost' ||
+						window.location.hostname === '127.0.0.1')
 
-		const params = new URLSearchParams(location.search);
-		const bucket = params.get("bucket");
-		const region = params.get("region");
-		const names = JSON.parse(params.get("names"));
-		const name = params.get("clicked");
-		const visualizationMode = params.get("mode");
-		const annotateLanesAvailable = params.get('annotate') == 'Annotate';
-		const downloadLanesAvailable = annotateLanesAvailable;
-		const calibrationModeAvailable = params.get("calibrate") == "Calibrate" || runForLocalDevelopment;
-		const accessKeyId = params.get("key1");
-		const secretAccessKey = params.get("key2");
-		const sessionToken = params.get("key3");
-		const fonts =  JSON.parse(params.get("fonts"));
-		const theme = JSON.parse(params.get("theme")); // material-ui theme
-		let comparisonDatasets = [];
+		const params = new URLSearchParams(location.search)
+		const bucket = params.get("bucket")
+		const region = params.get("region")
+		const names = JSON.parse(params.get("names"))
+		const name = params.get("clicked")
+		const visualizationMode = params.get("mode")
+		const annotateLanesAvailable = params.get('annotate') == 'Annotate'
+		const downloadLanesAvailable = annotateLanesAvailable
+		const calibrationModeAvailable = params.get("calibrate") == "Calibrate" ||
+				runForLocalDevelopment
+		let customTimeInterval = decanonicalizeTimeInterval({
+			start: params.get("start"), end: params.get("end")
+		})
+		const accessKeyId = params.get("key1")
+		const secretAccessKey = params.get("key2")
+		const sessionToken = params.get("key3")
+		const fonts = JSON.parse(params.get("fonts"))
+		const theme = JSON.parse(params.get("theme")) // material-ui theme
+		let comparisonDatasets = []
 		if (names) {
-			comparisonDatasets = names.filter(element => element !== name);
+			comparisonDatasets = names.filter(element => element !== name)
 		}
 
 		if (fonts) {
-			const head = document.head;
+			const head = document.head
 			fonts.forEach(font => {
-				const link = document.createElement('link');
-				link.rel = 'stylesheet';
-				link.href = font;
-				head.appendChild(link);
-			});
+				const link = document.createElement('link')
+				link.rel = 'stylesheet'
+				link.href = font
+				head.appendChild(link)
+			})
 
 			// Override fonts specified.
-			const {typography} = theme;
-			const style = document.createElement('style');
-			style.innerHTML = `#value {font-family: ${typography.fontFamily} !important;} #sidebar_root {font-family: ${typography.fontFamily} !important;} #potree_languages {font-family: ${typography.fontFamily} !important;}`;
-			head.appendChild(style);
+			const {typography} = theme
+			const style = document.createElement('style')
+			style.innerHTML =
+					`#value {font-family: ${typography.fontFamily} !important;} #sidebar_root {font-family: ${typography.fontFamily} !important;} #potree_languages {font-family: ${typography.fontFamily} !important;}`
+			head.appendChild(style)
 		}
 
     const s3 = bucket && region && name && accessKeyId && secretAccessKey &&
@@ -344,8 +361,6 @@
 				}
 			});
 
-
-
 			// Load Data Sources in loadRtkCallback:
 			loadRtkCallback(s3, bucket, name, () => {
 
@@ -409,7 +424,7 @@
 				try {
 					// await loadRadarCallback(s3, bucket, name);
 				} catch (e) {
-					console.error("Could not load Radar Detections: ", e);
+					console.error("Could not load Radar Detections: ", e)
 				}
 
 				// Load Detections:
@@ -419,152 +434,190 @@
 				// TODO
 
 				// Configure AnimationEngine:
-				// let tstart = window.timeframe.tstart;	// Set in loadRtkCallback
-				// let tend = window.timeframe.tend;			// Set in loadRtkCallback
-				// let playbackRate = 1.0;
-				// animationEngine.configure(tstart, tend, playbackRate);
+				// reconfigureTimeInterval();
 				// animationEngine.launch();
 			}); // END loadRtkCallback()
 
 		}); // END $(document).ready()
 
+		window.addEventListener("message", ({data}) => {
+			if (data.type === "updateTimeInterval") {
+				const {start, end} = data
+				customTimeInterval = decanonicalizeTimeInterval({start, end})
+				relaunchAnimationWithNewInterval()
+			}
+		}, false)
 
+		function relaunchAnimationWithNewInterval() {
+			const tstart = customTimeInterval ?
+					(window.fullTimeInterval.start + customTimeInterval.start) :
+					window.fullTimeInterval.start
+			const tend = customTimeInterval ?
+					(window.fullTimeInterval.start + customTimeInterval.end) :
+					window.fullTimeInterval.end
+			const playbackRate = 1.0
+			animationEngine.configure(tstart, tend, playbackRate)
+			animationEngine.launch()
+		}
 
-
-		// Load RTK: TODO REFACTOR THIS (a lot of stuff happenning here, break it up if possible)
+		// Load RTK: TODO REFACTOR THIS (a lot of stuff happening here, break it up if possible)
 		function loadRtkCallback(s3, bucket, name, callback) {
 			// loadRtk(s3, bucket, name, (pos, rot, timestamps, t_init, t_range) => {
-			loadRtkFlatbuffer(s3, bucket, name, (pos, rot, timestamps, t_init, t_range) => {
-				window.timeframe = {"tstart": t_init, "tend": t_init+t_range};
+			loadRtkFlatbuffer(s3, bucket, name,
+					(pos, rot, timestamps, t_init, t_range) => {
+						window.fullTimeInterval = {
+							start: t_init, end: t_init + t_range
+						}
 
-				// TODO Move this into main loader function:
-				let tstart = window.timeframe.tstart;	// Set in loadRtkCallback
-				let tend = window.timeframe.tend;			// Set in loadRtkCallback
-				let playbackRate = 1.0;
-				animationEngine.configure(tstart, tend, playbackRate);
-				animationEngine.launch();
+						// TODO Move this into main loader function:
+						relaunchAnimationWithNewInterval()
 
-				if (callback) {
-					callback();
-				}
+						if (callback) {
+							callback()
+						}
 
-	      const path = pos.map(v => new THREE.Vector3(...v));
-	      const orientations = rot.map(v => new THREE.Vector3(...v));
-				const samplingFreq = 100; // Hertz TODO hardcoded
-				const rtkTrajectory = new RtkTrajectory(path, orientations, timestamps, samplingFreq);
-				const closedPath = false;
+						const path = pos.map(v => new THREE.Vector3(...v))
+						const orientations = rot.map(v => new THREE.Vector3(...v))
+						const samplingFreq = 100 // Hertz TODO hardcoded
+						const rtkTrajectory = new RtkTrajectory(path, orientations,
+								timestamps, samplingFreq)
+						const closedPath = false
 
-	      // CREATE VEHICLE OBJECT:
-	      // NOTE for Mustang: {texture: models/bodybkgd.JPG, mesh: models/1967-shelby-ford-mustang.obj}
-	      // NOTE for Volt: {texture: models/Chevy_Volt_Segmented/Chevrolet_Volt_v1_exterior.png, mesh: resources/models/Chevy_Volt_Segmented/Chevy_Volt_2016.obj}
-	      let manager = new THREE.LoadingManager();
-	      manager.onProgress = function ( item, loaded, total ) {
-	        console.log( item, loaded, total );
-	      };
-	      let textureLoader = new THREE.TextureLoader( manager );
-	      let texture = textureLoader.load(`${Potree.resourcePath}/models/Chevy_Volt_Segmented/reflection_1.png`);
-	      // let texture = textureLoader.load(`${Potree.resourcePath}/models/bodybkgd.JPG`);
-	      let onProgress = function ( xhr ) {
-	        if ( xhr.lengthComputable ) {
-	          let percentComplete = xhr.loaded / xhr.total * 100;
-	        }
-	      };
-	      texture.wrapS = THREE.RepeatWrapping;
-	      texture.wrapT = THREE.RepeatWrapping;
-
-	      let geometry = new THREE.SphereGeometry( 2, 32, 32 );
-	      let material = new THREE.MeshNormalMaterial( {side: THREE.DoubleSide, opacity: 0.92,transparent:true});
-	      let sphere = new THREE.Mesh( geometry, material );
-	      sphere.position.copy(new THREE.Vector3(...pos[0]));
-	      // viewer.scene.scene.add( sphere );
-
-
-	      { // Load Textured vehicle from obj
-	        let onError = function ( xhr ) {};
-	        let loader = new THREE.OBJLoader( manager );
-	        loader.load(`${Potree.resourcePath}/models/Chevy_Volt_Segmented/volt_reduce.obj`,
-	        // loader.load(`${Potree.resourcePath}/models/Chevy_Volt_Segmented/Chevy_Volt_2016.obj`,
-	                    function ( object ) {
-	          object.traverse( function ( child ) {
-	            if ( child instanceof THREE.Mesh ) {
-	              child.material.map = texture;
-	            }
-	          } );
-
-						const vehicleGroup = new THREE.Group();
-						vehicleGroup.name = "Vehicle";
-
-			      { // render the path
-							let geometry = new THREE.Geometry();
-							for (let ii = 0; ii < rtkTrajectory.numStates; ii++) {
-								geometry.vertices[ii] = rtkTrajectory.states[ii].pose.clone();
+						// CREATE VEHICLE OBJECT:
+						// NOTE for Mustang: {texture: models/bodybkgd.JPG, mesh: models/1967-shelby-ford-mustang.obj}
+						// NOTE for Volt: {texture: models/Chevy_Volt_Segmented/Chevrolet_Volt_v1_exterior.png, mesh: resources/models/Chevy_Volt_Segmented/Chevy_Volt_2016.obj}
+						let manager = new THREE.LoadingManager()
+						manager.onProgress = function (item, loaded, total) {
+							console.log(item, loaded, total)
+						}
+						let textureLoader = new THREE.TextureLoader(manager)
+						let texture = textureLoader.load(
+								`${Potree.resourcePath}/models/Chevy_Volt_Segmented/reflection_1.png`)
+						// let texture = textureLoader.load(`${Potree.resourcePath}/models/bodybkgd.JPG`);
+						let onProgress = function (xhr) {
+							if (xhr.lengthComputable) {
+								let percentComplete = xhr.loaded / xhr.total * 100
 							}
-			        let material = new THREE.LineBasicMaterial({color: new THREE.Color(0x00ff00)});
-			        material.uniforms = {initialTime:{value:t_init}};
-							// material.opacity = 0.0;
-							// material.transparent = true;
-			        let line = new THREE.Line(geometry, material, {closed: closedPath});
-			        line.name = "RTK Trajectory";
-							line.visible = false;
-							viewer.scene.scene.add( line );
-							viewer.scene.dispatchEvent({"type": "vehicle_layer_added", "vehicleLayer": line });
-			      }
+						}
+						texture.wrapS = THREE.RepeatWrapping
+						texture.wrapT = THREE.RepeatWrapping
 
-						// Add Polar Grid Helper:
-						const gridRadius = 100; // meters
-						const gridSpacing = 5; // meters
-						const scaleFactor = 1; // HACK for now because attached to vehicle mesh which is 1/100th scale
-						const gridHelper = new THREE.GridHelper( scaleFactor*2*gridRadius, 2*gridRadius/gridSpacing, 0x0000ff, 0x808080 );
-						gridHelper.name = "Cartesian Grid";
-						gridHelper.rotateOnAxis(new THREE.Vector3(1,0,0), Math.PI/2);
-						gridHelper.position.z -= 2;
-						gridHelper.visible = false;
-						viewer.scene.dispatchEvent({"type": "vehicle_layer_added", "vehicleLayer": gridHelper });
-						const polarGridHelper = new THREE.PolarGridHelper( scaleFactor*gridRadius, 16, gridRadius/gridSpacing, 64, 0x0000ff, 0x808080 );
-						polarGridHelper.name = "Polar Grid";
-						polarGridHelper.rotateOnAxis(new THREE.Vector3(1,0,0), Math.PI/2);
-						polarGridHelper.position.z -= 2;
-						polarGridHelper.visible = false;
-						viewer.scene.dispatchEvent({"type": "vehicle_layer_added", "vehicleLayer": polarGridHelper });
-						const axesHelper = new THREE.AxesHelper(scaleFactor*gridSpacing);
-						axesHelper.name = "3D Axes";
-						axesHelper.position.z -= 2;
-						// axesHelper.rotateOnAxis(new THREE.Vector3(0,0,1), -Math.PI/2);
-						axesHelper.visible = false;
-						viewer.scene.dispatchEvent({"type": "vehicle_layer_added", "vehicleLayer": axesHelper });
+						let geometry = new THREE.SphereGeometry(2, 32, 32)
+						let material = new THREE.MeshNormalMaterial(
+								{side: THREE.DoubleSide, opacity: 0.92, transparent: true})
+						let sphere = new THREE.Mesh(geometry, material)
+						sphere.position.copy(new THREE.Vector3(...pos[0]))
+						// viewer.scene.scene.add( sphere );
 
+						{ // Load Textured vehicle from obj
+							let onError = function (xhr) {
+							}
+							let loader = new THREE.OBJLoader(manager)
+							loader.load(
+									`${Potree.resourcePath}/models/Chevy_Volt_Segmented/volt_reduce.obj`,
+									// loader.load(`${Potree.resourcePath}/models/Chevy_Volt_Segmented/Chevy_Volt_2016.obj`,
+									function (object) {
+										object.traverse(function (child) {
+											if (child instanceof THREE.Mesh) {
+												child.material.map = texture
+											}
+										})
 
-						vehicleGroup.add( gridHelper );
-						vehicleGroup.add( polarGridHelper );
-						vehicleGroup.add( axesHelper );
+										const vehicleGroup = new THREE.Group()
+										vehicleGroup.name = "Vehicle"
 
-						// Apply RTK to Vehicle Mesh Extrinsics:
-	          object.name = "Vehicle Mesh";
-	          object.scale.multiplyScalar(.01);
-						object.rotation.set(0*Math.PI / 2, 0*Math.PI/2., 1*Math.PI/2.0); // Chevy Volt
-						object.position.sub(new THREE.Vector3(0, 0, 2)); // Chevy Volt
+										{ // render the path
+											let geometry = new THREE.Geometry()
+											for (let ii = 0; ii < rtkTrajectory.numStates; ii++) {
+												geometry.vertices[ii] =
+														rtkTrajectory.states[ii].pose.clone()
+											}
+											let material = new THREE.LineBasicMaterial(
+													{color: new THREE.Color(0x00ff00)})
+											material.uniforms = {initialTime: {value: t_init}}
+											// material.opacity = 0.0;
+											// material.transparent = true;
+											let line = new THREE.Line(geometry, material,
+													{closed: closedPath})
+											line.name = "RTK Trajectory"
+											line.visible = false
+											viewer.scene.scene.add(line)
+											viewer.scene.dispatchEvent({
+												"type": "vehicle_layer_added", "vehicleLayer": line
+											})
+										}
 
-						// Initialize Vehicle Group:
-						vehicleGroup.position.set(...pos[0]);
-						applyRotation(vehicleGroup, rot[0][0], rot[0][1], rot[0][2]);
-						vehicleGroup.rotation.set(...rot[0]);
-						vehicleGroup.rtkTrajectory = rtkTrajectory;
-						vehicleGroup.add( object );
+										// Add Polar Grid Helper:
+										const gridRadius = 100 // meters
+										const gridSpacing = 5 // meters
+										const scaleFactor = 1 // HACK for now because attached to vehicle mesh which is 1/100th scale
+										const gridHelper = new THREE.GridHelper(
+												scaleFactor * 2 * gridRadius,
+												2 * gridRadius / gridSpacing, 0x0000ff, 0x808080)
+										gridHelper.name = "Cartesian Grid"
+										gridHelper.rotateOnAxis(new THREE.Vector3(1, 0, 0),
+												Math.PI / 2)
+										gridHelper.position.z -= 2
+										gridHelper.visible = false
+										viewer.scene.dispatchEvent({
+											"type": "vehicle_layer_added", "vehicleLayer": gridHelper
+										})
+										const polarGridHelper = new THREE.PolarGridHelper(
+												scaleFactor * gridRadius, 16, gridRadius / gridSpacing,
+												64, 0x0000ff, 0x808080)
+										polarGridHelper.name = "Polar Grid"
+										polarGridHelper.rotateOnAxis(new THREE.Vector3(1, 0, 0),
+												Math.PI / 2)
+										polarGridHelper.position.z -= 2
+										polarGridHelper.visible = false
+										viewer.scene.dispatchEvent({
+											"type": "vehicle_layer_added",
+											"vehicleLayer": polarGridHelper
+										})
+										const axesHelper = new THREE.AxesHelper(
+												scaleFactor * gridSpacing)
+										axesHelper.name = "3D Axes"
+										axesHelper.position.z -= 2
+										// axesHelper.rotateOnAxis(new THREE.Vector3(0,0,1), -Math.PI/2);
+										axesHelper.visible = false
+										viewer.scene.dispatchEvent({
+											"type": "vehicle_layer_added", "vehicleLayer": axesHelper
+										})
 
-						// TODO New Camera Initialization:
-						let box = new THREE.Box3().setFromObject(vehicleGroup);
-						let node = new THREE.Object3D();
-						node.boundingBox = box;
-						viewer.zoomTo(node, 0.1, 500);
-						// viewer.scene.view.lookAt(object.position);
+										vehicleGroup.add(gridHelper)
+										vehicleGroup.add(polarGridHelper)
+										vehicleGroup.add(axesHelper)
 
-	          // viewer.scene.scene.add( object );
-	          viewer.scene.scene.add( vehicleGroup );
-						viewer.scene.dispatchEvent({"type": "vehicle_layer_added", "vehicleLayer": object });
+										// Apply RTK to Vehicle Mesh Extrinsics:
+										object.name = "Vehicle Mesh"
+										object.scale.multiplyScalar(.01)
+										object.rotation.set(0 * Math.PI / 2, 0 * Math.PI / 2.,
+												1 * Math.PI / 2.0) // Chevy Volt
+										object.position.sub(new THREE.Vector3(0, 0, 2)) // Chevy Volt
 
-						viewer.setFilterGPSTimeRange(0, 0); // Size 0 Time Window at start of timeline
-						removeLoadingScreen();
-	        }, onProgress, onError );
+										// Initialize Vehicle Group:
+										vehicleGroup.position.set(...pos[0])
+										applyRotation(vehicleGroup, rot[0][0], rot[0][1], rot[0][2])
+										vehicleGroup.rotation.set(...rot[0])
+										vehicleGroup.rtkTrajectory = rtkTrajectory
+										vehicleGroup.add(object)
+
+										// TODO New Camera Initialization:
+										let box = new THREE.Box3().setFromObject(vehicleGroup)
+										let node = new THREE.Object3D()
+										node.boundingBox = box
+										viewer.zoomTo(node, 0.1, 500)
+										// viewer.scene.view.lookAt(object.position);
+
+										// viewer.scene.scene.add( object );
+										viewer.scene.scene.add(vehicleGroup)
+										viewer.scene.dispatchEvent({
+											"type": "vehicle_layer_added", "vehicleLayer": object
+										})
+
+										viewer.setFilterGPSTimeRange(0, 0) // Size 0 Time Window at start of timeline
+										removeLoadingScreen()
+									}, onProgress, onError)
 	      }
 
 	      // ANIMATION:

--- a/demo/radar.html
+++ b/demo/radar.html
@@ -5,38 +5,44 @@
 	<meta charset="utf-8">
 	<meta name="description" content="">
 	<meta name="author" content="">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+	<meta name="viewport"
+		content="width=device-width, initial-scale=1.0, user-scalable=no">
 	<title>Potree Viewer</title>
-
 	<link rel="stylesheet" type="text/css" href="../build/potree/potree.css">
-	<link rel="stylesheet" type="text/css" href="../libs/jquery-ui/jquery-ui.min.css">
-	<link rel="stylesheet" type="text/css" href="../libs/perfect-scrollbar/css/perfect-scrollbar.css">
+	<link rel="stylesheet" type="text/css"
+		href="../libs/jquery-ui/jquery-ui.min.css">
+	<link rel="stylesheet" type="text/css"
+		href="../libs/perfect-scrollbar/css/perfect-scrollbar.css">
 	<link rel="stylesheet" type="text/css" href="../libs/openlayers3/ol.css">
 	<link rel="stylesheet" type="text/css" href="../libs/spectrum/spectrum.css">
-	<link rel="stylesheet" type="text/css" href="../libs/jstree/themes/mixed/style.css">
+	<link rel="stylesheet" type="text/css"
+		href="../libs/jstree/themes/mixed/style.css">
 	<link rel="stylesheet" href="../common/overlay.css" type="text/css">
-	<link rel="stylesheet" href="../common/calibration-panels.css" type="text/css">
+	<link rel="stylesheet" href="../common/calibration-panels.css"
+		type="text/css">
 	<link rel="stylesheet" href="../common/loading-bar.css" type="text/css">
-  <!-- <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet"> -->
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+	<!-- <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet"> -->
+	<link href="https://fonts.googleapis.com/icon?family=Material+Icons"
+		rel="stylesheet">
 	<script src="../node_modules/flatbuffers/js/flatbuffers.js"></script>
 	<!-- <script type="module" src="../readers/polyline3D.js"></script>
 	<script type="module" src="../schemas/GroundTruth_generated_tmp.js"></script> -->
-  <script type="module" src="radarLoader.js"></script>
-  <script type="module" src="rtkLoader.js"></script>
-  <script type="module" src="rtkLoaderFlatbuffer.js"></script>
-  <script type="module" src="laneLoader.js"></script>
-  <script type="module" src="trackLoader.js"></script>
-  <script type="module" src="gapsLoader.js"></script>
+	<script type="module" src="radarLoader.js"></script>
+	<script type="module" src="rtkLoader.js"></script>
+	<script type="module" src="rtkLoaderFlatbuffer.js"></script>
+	<script type="module" src="laneLoader.js"></script>
+	<script type="module" src="trackLoader.js"></script>
+	<script type="module" src="gapsLoader.js"></script>
 	<script type="module" src="remLoader.js"></script>
 	<script type="module" src="calibrationManager.js"></script>
-  <link rel="stylesheet" type="text/css" href="../common/playbar.css">
+	<link rel="stylesheet" type="text/css" href="../common/playbar.css">
 </head>
 
 <body>
 	<script src="../libs/jquery/jquery-3.1.1.min.js"></script>
 	<script src="../libs/spectrum/spectrum.js"></script>
-	<script src="../libs/perfect-scrollbar/js/perfect-scrollbar.jquery.js"></script>
+	<script
+		src="../libs/perfect-scrollbar/js/perfect-scrollbar.jquery.js"></script>
 	<script src="../libs/jquery-ui/jquery-ui.min.js"></script>
 	<script src="../libs/three.js/build/three.min.js"></script>
 	<script src="../libs/other/BinaryHeap.js"></script>
@@ -48,7 +54,7 @@
 	<script src="../libs/jstree/jstree.js"></script>
 	<script src="../build/potree/potree.js"></script>
 	<script src="../libs/plasio/js/laslaz.js"></script>
-  <script src="../libs/other/OBJLoader.js"></script>
+	<script src="../libs/other/OBJLoader.js"></script>
 	<script src="../common/playbar.js"></script>
 	<script src="../common/loading-bar.js"></script>
 	<script type="module" src="../common/overlay.js"></script>
@@ -57,28 +63,18 @@
 	<script src="animationEngine.js"></script>
 	<script type="module" src="RtkTrajectory.js"></script>
 	<script type="module" src="../src/loader/PointAttributes.js"></script>
-
-
 	<!-- TODO REMOVE BELOW -->
 	<script src="tweenTest.js"></script>
-
-
-
 	<!-- <script src="../common/playbar.css"></script> -->
-
-
 	<!-- INCLUDE ADDITIONAL DEPENDENCIES HERE -->
-  <script src="https://sdk.amazonaws.com/js/aws-sdk-2.339.0.min.js"></script>
-
+	<script src="https://sdk.amazonaws.com/js/aws-sdk-2.339.0.min.js"></script>
 	<!-- INCLUDE SETTINGS HERE -->
-
-	<div class="potree_container" style="position: absolute; width: 100%; height: 100%; left: 0px; top: 0px; ">
-	  <div id="potree_render_area"></div>
+	<div class="potree_container"
+		style="position: absolute; width: 100%; height: 100%; left: 0px; top: 0px; ">
+		<div id="potree_render_area"></div>
 		<div id="potree_sidebar_container"></div>
 	</div>
-
-
-  <script type="x-shader/x-vertex" id="vertexshader">
+	<script type="x-shader/x-vertex" id="vertexshader">
 
       attribute float alpha;
       attribute float gpsTime;
@@ -117,8 +113,7 @@
       }
 
   </script>
-
-  <script type="x-shader/x-fragment" id="fragmentshader">
+	<script type="x-shader/x-fragment" id="fragmentshader">
 
       uniform vec3 color;
 
@@ -131,32 +126,27 @@
       }
 
   </script>
-
-
-
-
-
 	<script type="module">
 		"use strict"
-		import {loadLanes} from "../demo/laneLoader.js"
-		import {loadTracks} from "../demo/trackLoader.js"
-		import {loadDetections} from "../demo/detectionLoader.js"
-		import {loadRtk, applyRotation} from "../demo/rtkLoader.js"
-		import {loadRtkFlatbuffer} from "../demo/rtkLoaderFlatbuffer.js"
-		import {RtkTrajectory} from "../demo/RtkTrajectory.js"
-		import {loadRadar} from "../demo/radarLoader.js"
-		import {loadGaps} from "../demo/gapsLoader.js"
-		import {loadRem} from "../demo/remLoader.js"
+		import { loadLanes } from "../demo/laneLoader.js"
+		import { loadTracks } from "../demo/trackLoader.js"
+		import { loadDetections } from "../demo/detectionLoader.js"
+		import { loadRtk, applyRotation } from "../demo/rtkLoader.js"
+		import { loadRtkFlatbuffer } from "../demo/rtkLoaderFlatbuffer.js"
+		import { RtkTrajectory } from "../demo/RtkTrajectory.js"
+		import { loadRadar } from "../demo/radarLoader.js"
+		import { loadGaps } from "../demo/gapsLoader.js"
+		import { loadRem } from "../demo/remLoader.js"
 		import {
 			loadVelo2Rtk, loadRtk2Vehicle, storeCalibration
 		} from "../demo/calibrationManager.js"
-		import {updateSidebar, togglePointClass} from "../common/custom-sidebar.js"
-		import {getLoadingBar} from "../common/overlay.js"
+		import { updateSidebar, togglePointClass } from "../common/custom-sidebar.js"
+		import { getLoadingBar } from "../common/overlay.js"
 		// import {  } from "../common/overlay.js";
-		import {setLoadingScreen, removeLoadingScreen} from "../common/overlay.js"
-		import {PointAttributeNames} from "../src/loader/PointAttributes.js"
+		import { setLoadingScreen, removeLoadingScreen } from "../common/overlay.js"
+		import { PointAttributeNames } from "../src/loader/PointAttributes.js"
 
-		function canonicalizeTimeInterval({start, end}) {
+		function canonicalizeTimeInterval({ start, end }) {
 			return [String(start), String(end)]
 		}
 
@@ -164,8 +154,12 @@
 			if (start === "" && end === "") {
 				return null
 			} else {
-				return {start: Number(start), end: Number(end)}
+				return { start: Number(start), end: Number(end) }
 			}
+		}
+
+		function shiftTimeInterval({ start, end }, offset) {
+			return { start: start + offset, end: end + offset }
 		}
 
 		const minAnimationStepDigits = 5
@@ -174,8 +168,8 @@
 		// setLoadingScreen();
 
 		const runForLocalDevelopment = location.search === "" &&
-				(window.location.hostname === 'localhost' ||
-						window.location.hostname === '127.0.0.1')
+			(window.location.hostname === 'localhost' ||
+				window.location.hostname === '127.0.0.1')
 
 		const params = new URLSearchParams(location.search)
 		const bucket = params.get("bucket")
@@ -186,7 +180,7 @@
 		const annotateLanesAvailable = params.get('annotate') == 'Annotate'
 		const downloadLanesAvailable = annotateLanesAvailable
 		const calibrationModeAvailable = params.get("calibrate") == "Calibrate" ||
-				runForLocalDevelopment
+			runForLocalDevelopment
 		const accessKeyId = params.get("key1")
 		const secretAccessKey = params.get("key2")
 		const sessionToken = params.get("key3")
@@ -197,7 +191,7 @@
 			comparisonDatasets = names.filter(element => element !== name)
 		}
 		let customLocalInterval = decanonicalizeTimeInterval(
-				[params.get("start"), params.get("end")])
+			[params.get("start"), params.get("end")])
 		let animationInterval = null
 
 		if (fonts) {
@@ -210,30 +204,31 @@
 			})
 
 			// Override fonts specified.
-			const {typography} = theme
+			const { typography } = theme
 			const style = document.createElement('style')
 			style.innerHTML =
-					`#value {font-family: ${typography.fontFamily} !important;} #sidebar_root {font-family: ${typography.fontFamily} !important;} #potree_languages {font-family: ${typography.fontFamily} !important;}`
+				`#value {font-family: ${typography.fontFamily} !important;} #sidebar_root {font-family: ${typography.fontFamily} !important;} #potree_languages {font-family: ${typography.fontFamily} !important;}`
 			head.appendChild(style)
 		}
 
-    const s3 = bucket && region && name && accessKeyId && secretAccessKey &&
-				new AWS.S3({region: region,
-							 accessKeyId: accessKeyId,
-							 secretAccessKey: secretAccessKey,
-							 sessionToken: sessionToken,
-							});
+		const s3 = bucket && region && name && accessKeyId && secretAccessKey &&
+			new AWS.S3({
+				region: region,
+				accessKeyId: accessKeyId,
+				secretAccessKey: secretAccessKey,
+				sessionToken: sessionToken,
+			});
 
-    if (!(s3 || window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')) { window.history.back() };
-    // We really want this, but it doesn't work in the browser. Only on a server.
-    // const stream = s3.getObject({Bucket: bucket,
-    //                              Key: name}).createReadStream();
+		if (!(s3 || window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')) { window.history.back() };
+		// We really want this, but it doesn't work in the browser. Only on a server.
+		// const stream = s3.getObject({Bucket: bucket,
+		//                              Key: name}).createReadStream();
 
-    window.viewer = new Potree.Viewer(document.getElementById("potree_render_area"));
+		window.viewer = new Potree.Viewer(document.getElementById("potree_render_area"));
 
 		viewer.setEDLEnabled(true);
 		viewer.setFOV(60);
-		viewer.setPointBudget(1*1000*1000);
+		viewer.setPointBudget(1 * 1000 * 1000);
 		document.title = "";
 		viewer.setEDLEnabled(false);
 		viewer.setBackground("gradient"); // ["skybox", "gradient", "black", "white"];
@@ -242,19 +237,19 @@
 
 		viewer.loadGUI(() => {
 			// Override Sidebar Potree Branding Panel:
-			document.getElementById("potree_branding").style.display="none";
-			document.getElementById("menu_about").style.display="none";
+			document.getElementById("potree_branding").style.display = "none";
+			document.getElementById("menu_about").style.display = "none";
 
 			viewer.setLanguage('en');
 			$("#menu_appearance").next().show();
 			$("#menu_tools").next().show();
 			$("#menu_scene").next().show();
 			// viewer.toggleSidebar();
-      // viewer.setNavigationMode(EarthControls); // TODO Hack: changed default in viewer.js line 234
-      // $('#show_bounding_box').trigger("click");
-      // $("#splat_quality_options_hq").trigger("click"); // NOTE: HQ Splat breaks OrthographicCamera
-      // viewer.scene.view.position.set(300198.109, 4701144.537, 349.871);
-      // viewer.scene.view.lookAt(new THREE.Vector3(299900.954, 4701576.919, 66.197));
+			// viewer.setNavigationMode(EarthControls); // TODO Hack: changed default in viewer.js line 234
+			// $('#show_bounding_box').trigger("click");
+			// $("#splat_quality_options_hq").trigger("click"); // NOTE: HQ Splat breaks OrthographicCamera
+			// viewer.scene.view.position.set(300198.109, 4701144.537, 349.871);
+			// viewer.scene.view.lookAt(new THREE.Vector3(299900.954, 4701576.919, 66.197));
 			updateSidebar(visualizationMode);
 
 			window.calibrationModeAvailable = calibrationModeAvailable;
@@ -262,7 +257,7 @@
 
 			if (visualizationMode == "aptivLanes") {
 				viewer.setCameraMode(Potree.CameraMode.ORTHOGRAPHIC);
-				viewer.scene.view.maxPitch = -Math.PI/2;
+				viewer.scene.view.maxPitch = -Math.PI / 2;
 
 				document.getElementById("toggle_calibration_panels").style.display = "none";
 				document.getElementById("load_detections_button").style.display = "none";
@@ -296,10 +291,10 @@
 
 		// TODO put these material definitions somewhere better
 		let uniforms = {
-			color: {value: new THREE.Color(0x00ff00)},
-			minGpsTime: {value: 0.0},
-			maxGpsTime: {value: 0.5},
-			initialTime: {value: 0} // TODO not used
+			color: { value: new THREE.Color(0x00ff00) },
+			minGpsTime: { value: 0.0 },
+			maxGpsTime: { value: 0.5 },
+			initialTime: { value: 0 } // TODO not used
 			// offset: {value: new THREE.Vector3(0,0,0)}
 		}
 		let shaderMaterial = new THREE.ShaderMaterial({
@@ -321,7 +316,7 @@
 
 			window.truthAnnotationMode = 0	// 0: None, 1: Delete, 2: Add
 			let annotationScreen = $(
-					`<div id="annotationScreen"><p id="annotation-label">ANNOTATION MODE: <b id="annotation-mode-text"></b></p></div>`)
+				`<div id="annotationScreen"><p id="annotation-label">ANNOTATION MODE: <b id="annotation-mode-text"></b></p></div>`)
 			$('body').prepend(annotationScreen)
 			let div = document.getElementById("annotationScreen")
 			div.style.opacity = 0
@@ -369,7 +364,7 @@
 			loadRtkCallback(s3, bucket, name, () => {
 
 				// Load Extrinsics:
-				window.extrinsics = {rtk2Vehicle: null, velo2Rtk: {}};
+				window.extrinsics = { rtk2Vehicle: null, velo2Rtk: {} };
 				try {
 					loadVelo2Rtk(s3, bucket, name, (velo2Rtk) => {
 
@@ -379,15 +374,15 @@
 						}
 
 						console.log("Velo2Rtk Extrinsics Loaded!");
-						window.extrinsics.velo2Rtk  = {old: velo2Rtk, new:velo2Rtk};
+						window.extrinsics.velo2Rtk = { old: velo2Rtk, new: velo2Rtk };
 						storeVelo2Rtk(window.extrinsics.velo2Rtk.new);
 						for (const cloud of viewer.scene.pointclouds) {
 
 							let velo2RtkOld = window.extrinsics.velo2Rtk.old;
 							let velo2RtkNew = window.extrinsics.velo2Rtk.new;
 
-					      	cloud.material.uniforms.velo2RtkXYZOld.value.set(velo2RtkOld.x, velo2RtkOld.y, velo2RtkOld.z);
-					      	cloud.material.uniforms.velo2RtkRPYOld.value.set(velo2RtkOld.roll, velo2RtkOld.pitch, velo2RtkOld.yaw);
+							cloud.material.uniforms.velo2RtkXYZOld.value.set(velo2RtkOld.x, velo2RtkOld.y, velo2RtkOld.z);
+							cloud.material.uniforms.velo2RtkRPYOld.value.set(velo2RtkOld.roll, velo2RtkOld.pitch, velo2RtkOld.yaw);
 							cloud.material.uniforms.velo2RtkXYZNew.value.set(velo2RtkNew.x, velo2RtkNew.y, velo2RtkNew.z);
 							cloud.material.uniforms.velo2RtkRPYNew.value.set(velo2RtkNew.roll, velo2RtkNew.pitch, velo2RtkNew.yaw);
 						}
@@ -395,7 +390,7 @@
 
 					loadRtk2Vehicle(s3, bucket, name, (rtk2Vehicle) => {
 						console.log("Rtk2Vehicle Extrinsics Loaded!");
-						window.extrinsics.rtk2Vehicle  = {old: rtk2Vehicle, new:rtk2Vehicle};
+						window.extrinsics.rtk2Vehicle = { old: rtk2Vehicle, new: rtk2Vehicle };
 						storeRtk2Vehicle(window.extrinsics.rtk2Vehicle.new);
 					});
 				} catch (e) {
@@ -418,7 +413,7 @@
 					console.error("Could not load Tracks: ", e);
 				}
 
-				try{
+				try {
 					loadRemCallback(s3, bucket, name, animationEngine);
 				} catch (e) {
 					console.error("No rem points: ", e);
@@ -444,19 +439,18 @@
 
 		}); // END $(document).ready()
 
-		window.addEventListener("message", ({origin, data}) => {
+		window.addEventListener("message", ({ origin, data }) => {
 			if (data.type === "updateTimeInterval" && origin !== window.origin) {
-				animationInterval = decanonicalizeTimeInterval(data.timeInterval)
-				relaunchWithNewInterval()
+				setAnimationInterval(shiftTimeInterval(decanonicalizeTimeInterval(data.timeInterval), window.fullTimeInterval.start))
 			}
 		}, false)
 
 		function updateTimeDisplay(newTime) {
 			document.getElementById("time_display").value =
-					(newTime - animationInterval.start).toFixed(minAnimationStepDigits)
+				(newTime - animationInterval.start).toFixed(minAnimationStepDigits)
 			document.getElementById("full_time_display").value =
-					(newTime - window.fullTimeInterval.start).toFixed(
-							minAnimationStepDigits)
+				(newTime - window.fullTimeInterval.start).toFixed(
+					minAnimationStepDigits)
 		}
 
 		function setAnimationTime(newTime) {
@@ -473,7 +467,7 @@
 			timeSlider.slider("option", "max", animationInterval.end)
 
 			if (animationEngine.timeline.t < animationInterval.start ||
-					animationEngine.timeline.t > animationInterval.end) {
+				animationEngine.timeline.t > animationInterval.end) {
 				relaunchWithNewInterval() // also calls animationEngine.stop()
 			} else {
 				animationEngine.stop()
@@ -483,7 +477,7 @@
 
 			window.parent.postMessage({
 				type: "updateTimeInterval",
-				timeInterval: canonicalizeTimeInterval(animationInterval)
+				timeInterval: canonicalizeTimeInterval(shiftTimeInterval(animationInterval, -fullTimeInterval.start))
 			}, "*")
 		}
 
@@ -493,11 +487,11 @@
 
 			animationInterval = {
 				start: customLocalInterval ?
-						(fullTimeInterval.start + customLocalInterval.start) :
-						fullTimeInterval.start,
+					(fullTimeInterval.start + customLocalInterval.start) :
+					fullTimeInterval.start,
 				end: customLocalInterval ?
-						(fullTimeInterval.start + customLocalInterval.end) :
-						fullTimeInterval.end
+					(fullTimeInterval.start + customLocalInterval.end) :
+					fullTimeInterval.end
 			}
 
 			$("#intervalSlider").slider({
@@ -507,7 +501,7 @@
 				values: [animationInterval.start, animationInterval.end],
 				step: minAnimationStep,
 				slide: (event, ui) => {
-					setAnimationInterval({start: ui.values[0], end: ui.values[1]})
+					setAnimationInterval({ start: ui.values[0], end: ui.values[1] })
 				}
 			})
 
@@ -527,13 +521,13 @@
 		function launchAnimationWithNewInterval() {
 			const playbackRate = 1.0
 			animationEngine.configure(animationInterval.start, animationInterval.end,
-					playbackRate)
+				playbackRate)
 			animationEngine.launch()
 		}
 
 		function updateIntervalSlider() {
 			$("#intervalSlider")
-					.slider("values", animationInterval.start, animationInterval.end)
+				.slider("values", animationInterval.start, animationInterval.end)
 		}
 
 		function relaunchWithNewInterval() {
@@ -545,213 +539,213 @@
 		function loadRtkCallback(s3, bucket, name, callback) {
 			// loadRtk(s3, bucket, name, (pos, rot, timestamps, t_init, t_range) => {
 			loadRtkFlatbuffer(s3, bucket, name,
-					(pos, rot, timestamps, t_init, t_range) => {
-						setupFullTimeInterval({start: t_init, end: t_init + t_range})
+				(pos, rot, timestamps, t_init, t_range) => {
+					setupFullTimeInterval({ start: t_init, end: t_init + t_range })
 
-						// TODO Move this into main loader function:
-						launchAnimationWithNewInterval()
+					// TODO Move this into main loader function:
+					launchAnimationWithNewInterval()
 
-						if (callback) {
-							callback()
+					if (callback) {
+						callback()
+					}
+
+					const path = pos.map(v => new THREE.Vector3(...v))
+					const orientations = rot.map(v => new THREE.Vector3(...v))
+					const samplingFreq = 100 // Hertz TODO hardcoded
+					const rtkTrajectory = new RtkTrajectory(path, orientations,
+						timestamps, samplingFreq)
+					const closedPath = false
+
+					// CREATE VEHICLE OBJECT:
+					// NOTE for Mustang: {texture: models/bodybkgd.JPG, mesh: models/1967-shelby-ford-mustang.obj}
+					// NOTE for Volt: {texture: models/Chevy_Volt_Segmented/Chevrolet_Volt_v1_exterior.png, mesh: resources/models/Chevy_Volt_Segmented/Chevy_Volt_2016.obj}
+					let manager = new THREE.LoadingManager()
+					manager.onProgress = function (item, loaded, total) {
+						console.log(item, loaded, total)
+					}
+					let textureLoader = new THREE.TextureLoader(manager)
+					let texture = textureLoader.load(
+						`${Potree.resourcePath}/models/Chevy_Volt_Segmented/reflection_1.png`)
+					// let texture = textureLoader.load(`${Potree.resourcePath}/models/bodybkgd.JPG`);
+					let onProgress = function (xhr) {
+						if (xhr.lengthComputable) {
+							let percentComplete = xhr.loaded / xhr.total * 100
 						}
+					}
+					texture.wrapS = THREE.RepeatWrapping
+					texture.wrapT = THREE.RepeatWrapping
 
-						const path = pos.map(v => new THREE.Vector3(...v))
-						const orientations = rot.map(v => new THREE.Vector3(...v))
-						const samplingFreq = 100 // Hertz TODO hardcoded
-						const rtkTrajectory = new RtkTrajectory(path, orientations,
-								timestamps, samplingFreq)
-						const closedPath = false
+					let geometry = new THREE.SphereGeometry(2, 32, 32)
+					let material = new THREE.MeshNormalMaterial(
+						{ side: THREE.DoubleSide, opacity: 0.92, transparent: true })
+					let sphere = new THREE.Mesh(geometry, material)
+					sphere.position.copy(new THREE.Vector3(...pos[0]))
+					// viewer.scene.scene.add( sphere );
 
-						// CREATE VEHICLE OBJECT:
-						// NOTE for Mustang: {texture: models/bodybkgd.JPG, mesh: models/1967-shelby-ford-mustang.obj}
-						// NOTE for Volt: {texture: models/Chevy_Volt_Segmented/Chevrolet_Volt_v1_exterior.png, mesh: resources/models/Chevy_Volt_Segmented/Chevy_Volt_2016.obj}
-						let manager = new THREE.LoadingManager()
-						manager.onProgress = function (item, loaded, total) {
-							console.log(item, loaded, total)
+					{ // Load Textured vehicle from obj
+						let onError = function (xhr) {
 						}
-						let textureLoader = new THREE.TextureLoader(manager)
-						let texture = textureLoader.load(
-								`${Potree.resourcePath}/models/Chevy_Volt_Segmented/reflection_1.png`)
-						// let texture = textureLoader.load(`${Potree.resourcePath}/models/bodybkgd.JPG`);
-						let onProgress = function (xhr) {
-							if (xhr.lengthComputable) {
-								let percentComplete = xhr.loaded / xhr.total * 100
-							}
-						}
-						texture.wrapS = THREE.RepeatWrapping
-						texture.wrapT = THREE.RepeatWrapping
-
-						let geometry = new THREE.SphereGeometry(2, 32, 32)
-						let material = new THREE.MeshNormalMaterial(
-								{side: THREE.DoubleSide, opacity: 0.92, transparent: true})
-						let sphere = new THREE.Mesh(geometry, material)
-						sphere.position.copy(new THREE.Vector3(...pos[0]))
-						// viewer.scene.scene.add( sphere );
-
-						{ // Load Textured vehicle from obj
-							let onError = function (xhr) {
-							}
-							let loader = new THREE.OBJLoader(manager)
-							loader.load(
-									`${Potree.resourcePath}/models/Chevy_Volt_Segmented/volt_reduce.obj`,
-									// loader.load(`${Potree.resourcePath}/models/Chevy_Volt_Segmented/Chevy_Volt_2016.obj`,
-									function (object) {
-										object.traverse(function (child) {
-											if (child instanceof THREE.Mesh) {
-												child.material.map = texture
-											}
-										})
-
-										const vehicleGroup = new THREE.Group()
-										vehicleGroup.name = "Vehicle"
-
-										{ // render the path
-											let geometry = new THREE.Geometry()
-											for (let ii = 0; ii < rtkTrajectory.numStates; ii++) {
-												geometry.vertices[ii] =
-														rtkTrajectory.states[ii].pose.clone()
-											}
-											let material = new THREE.LineBasicMaterial(
-													{color: new THREE.Color(0x00ff00)})
-											material.uniforms = {initialTime: {value: t_init}}
-											// material.opacity = 0.0;
-											// material.transparent = true;
-											let line = new THREE.Line(geometry, material,
-													{closed: closedPath})
-											line.name = "RTK Trajectory"
-											line.visible = false
-											viewer.scene.scene.add(line)
-											viewer.scene.dispatchEvent({
-												"type": "vehicle_layer_added", "vehicleLayer": line
-											})
-										}
-
-										// Add Polar Grid Helper:
-										const gridRadius = 100 // meters
-										const gridSpacing = 5 // meters
-										const scaleFactor = 1 // HACK for now because attached to vehicle mesh which is 1/100th scale
-										const gridHelper = new THREE.GridHelper(
-												scaleFactor * 2 * gridRadius,
-												2 * gridRadius / gridSpacing, 0x0000ff, 0x808080)
-										gridHelper.name = "Cartesian Grid"
-										gridHelper.rotateOnAxis(new THREE.Vector3(1, 0, 0),
-												Math.PI / 2)
-										gridHelper.position.z -= 2
-										gridHelper.visible = false
-										viewer.scene.dispatchEvent({
-											"type": "vehicle_layer_added", "vehicleLayer": gridHelper
-										})
-										const polarGridHelper = new THREE.PolarGridHelper(
-												scaleFactor * gridRadius, 16, gridRadius / gridSpacing,
-												64, 0x0000ff, 0x808080)
-										polarGridHelper.name = "Polar Grid"
-										polarGridHelper.rotateOnAxis(new THREE.Vector3(1, 0, 0),
-												Math.PI / 2)
-										polarGridHelper.position.z -= 2
-										polarGridHelper.visible = false
-										viewer.scene.dispatchEvent({
-											"type": "vehicle_layer_added",
-											"vehicleLayer": polarGridHelper
-										})
-										const axesHelper = new THREE.AxesHelper(
-												scaleFactor * gridSpacing)
-										axesHelper.name = "3D Axes"
-										axesHelper.position.z -= 2
-										// axesHelper.rotateOnAxis(new THREE.Vector3(0,0,1), -Math.PI/2);
-										axesHelper.visible = false
-										viewer.scene.dispatchEvent({
-											"type": "vehicle_layer_added", "vehicleLayer": axesHelper
-										})
-
-										vehicleGroup.add(gridHelper)
-										vehicleGroup.add(polarGridHelper)
-										vehicleGroup.add(axesHelper)
-
-										// Apply RTK to Vehicle Mesh Extrinsics:
-										object.name = "Vehicle Mesh"
-										object.scale.multiplyScalar(.01)
-										object.rotation.set(0 * Math.PI / 2, 0 * Math.PI / 2.,
-												1 * Math.PI / 2.0) // Chevy Volt
-										object.position.sub(new THREE.Vector3(0, 0, 2)) // Chevy Volt
-
-										// Initialize Vehicle Group:
-										vehicleGroup.position.set(...pos[0])
-										applyRotation(vehicleGroup, rot[0][0], rot[0][1], rot[0][2])
-										vehicleGroup.rotation.set(...rot[0])
-										vehicleGroup.rtkTrajectory = rtkTrajectory
-										vehicleGroup.add(object)
-
-										// TODO New Camera Initialization:
-										let box = new THREE.Box3().setFromObject(vehicleGroup)
-										let node = new THREE.Object3D()
-										node.boundingBox = box
-										viewer.zoomTo(node, 0.1, 500)
-										// viewer.scene.view.lookAt(object.position);
-
-										// viewer.scene.scene.add( object );
-										viewer.scene.scene.add(vehicleGroup)
-										viewer.scene.dispatchEvent({
-											"type": "vehicle_layer_added", "vehicleLayer": object
-										})
-
-										viewer.setFilterGPSTimeRange(0, 0) // Size 0 Time Window at start of timeline
-										removeLoadingScreen()
-									}, onProgress, onError)
-						}
-
-						// ANIMATION:
-						{ // create Animation Path & make light follow it
-							{// ANIMATION + SLIDER LOGIC:
-								let time_display = document.getElementById("time_display")
-								let tmin = document.getElementById("playbar_tmin")
-								let tmax = document.getElementById("playbar_tmax")
-								let zmin = document.getElementById("elevation_min")
-								let zmax = document.getElementById("elevation_max")
-
-								// Playbar Button Functions:
-								let playbutton = document.getElementById("playbutton")
-								let pausebutton = document.getElementById("pausebutton")
-								pausebutton.addEventListener("mousedown", () => {
-									animationEngine.stop()
-								})
-								playbutton.addEventListener("mousedown", () => {
-									animationEngine.start()
-								})
-
-								time_display.addEventListener('keyup', function onEvent(e) {
-									if (e.keyCode === 13) {
-										animationEngine.stop()
-										const newValue = parseFloat(time_display.value)
-										if (newValue) {
-											const newTime = Math.min(animationEngine.timeRange,
-													Math.max(0, newValue)) + animationInterval.start
-											setAnimationTime(newTime)
-										}
+						let loader = new THREE.OBJLoader(manager)
+						loader.load(
+							`${Potree.resourcePath}/models/Chevy_Volt_Segmented/volt_reduce.obj`,
+							// loader.load(`${Potree.resourcePath}/models/Chevy_Volt_Segmented/Chevy_Volt_2016.obj`,
+							function (object) {
+								object.traverse(function (child) {
+									if (child instanceof THREE.Mesh) {
+										child.material.map = texture
 									}
 								})
 
-								zmin.addEventListener("input", () => {
-									window.elevationWindow.min = Math.abs(Number(zmin.value))
-									window.elevationWindow.max = Math.abs(Number(zmax.value))
-									animationEngine.updateTimeForAll()
+								const vehicleGroup = new THREE.Group()
+								vehicleGroup.name = "Vehicle"
+
+								{ // render the path
+									let geometry = new THREE.Geometry()
+									for (let ii = 0; ii < rtkTrajectory.numStates; ii++) {
+										geometry.vertices[ii] =
+											rtkTrajectory.states[ii].pose.clone()
+									}
+									let material = new THREE.LineBasicMaterial(
+										{ color: new THREE.Color(0x00ff00) })
+									material.uniforms = { initialTime: { value: t_init } }
+									// material.opacity = 0.0;
+									// material.transparent = true;
+									let line = new THREE.Line(geometry, material,
+										{ closed: closedPath })
+									line.name = "RTK Trajectory"
+									line.visible = false
+									viewer.scene.scene.add(line)
+									viewer.scene.dispatchEvent({
+										"type": "vehicle_layer_added", "vehicleLayer": line
+									})
+								}
+
+								// Add Polar Grid Helper:
+								const gridRadius = 100 // meters
+								const gridSpacing = 5 // meters
+								const scaleFactor = 1 // HACK for now because attached to vehicle mesh which is 1/100th scale
+								const gridHelper = new THREE.GridHelper(
+									scaleFactor * 2 * gridRadius,
+									2 * gridRadius / gridSpacing, 0x0000ff, 0x808080)
+								gridHelper.name = "Cartesian Grid"
+								gridHelper.rotateOnAxis(new THREE.Vector3(1, 0, 0),
+									Math.PI / 2)
+								gridHelper.position.z -= 2
+								gridHelper.visible = false
+								viewer.scene.dispatchEvent({
+									"type": "vehicle_layer_added", "vehicleLayer": gridHelper
+								})
+								const polarGridHelper = new THREE.PolarGridHelper(
+									scaleFactor * gridRadius, 16, gridRadius / gridSpacing,
+									64, 0x0000ff, 0x808080)
+								polarGridHelper.name = "Polar Grid"
+								polarGridHelper.rotateOnAxis(new THREE.Vector3(1, 0, 0),
+									Math.PI / 2)
+								polarGridHelper.position.z -= 2
+								polarGridHelper.visible = false
+								viewer.scene.dispatchEvent({
+									"type": "vehicle_layer_added",
+									"vehicleLayer": polarGridHelper
+								})
+								const axesHelper = new THREE.AxesHelper(
+									scaleFactor * gridSpacing)
+								axesHelper.name = "3D Axes"
+								axesHelper.position.z -= 2
+								// axesHelper.rotateOnAxis(new THREE.Vector3(0,0,1), -Math.PI/2);
+								axesHelper.visible = false
+								viewer.scene.dispatchEvent({
+									"type": "vehicle_layer_added", "vehicleLayer": axesHelper
 								})
 
-								zmax.addEventListener("input", () => {
-									window.elevationWindow.min = Math.abs(Number(zmin.value))
-									window.elevationWindow.max = Math.abs(Number(zmax.value))
-									animationEngine.updateTimeForAll()
+								vehicleGroup.add(gridHelper)
+								vehicleGroup.add(polarGridHelper)
+								vehicleGroup.add(axesHelper)
+
+								// Apply RTK to Vehicle Mesh Extrinsics:
+								object.name = "Vehicle Mesh"
+								object.scale.multiplyScalar(.01)
+								object.rotation.set(0 * Math.PI / 2, 0 * Math.PI / 2.,
+									1 * Math.PI / 2.0) // Chevy Volt
+								object.position.sub(new THREE.Vector3(0, 0, 2)) // Chevy Volt
+
+								// Initialize Vehicle Group:
+								vehicleGroup.position.set(...pos[0])
+								applyRotation(vehicleGroup, rot[0][0], rot[0][1], rot[0][2])
+								vehicleGroup.rotation.set(...rot[0])
+								vehicleGroup.rtkTrajectory = rtkTrajectory
+								vehicleGroup.add(object)
+
+								// TODO New Camera Initialization:
+								let box = new THREE.Box3().setFromObject(vehicleGroup)
+								let node = new THREE.Object3D()
+								node.boundingBox = box
+								viewer.zoomTo(node, 0.1, 500)
+								// viewer.scene.view.lookAt(object.position);
+
+								// viewer.scene.scene.add( object );
+								viewer.scene.scene.add(vehicleGroup)
+								viewer.scene.dispatchEvent({
+									"type": "vehicle_layer_added", "vehicleLayer": object
 								})
-							}
-	      }
-	    });
+
+								viewer.setFilterGPSTimeRange(0, 0) // Size 0 Time Window at start of timeline
+								removeLoadingScreen()
+							}, onProgress, onError)
+					}
+
+					// ANIMATION:
+					{ // create Animation Path & make light follow it
+						{// ANIMATION + SLIDER LOGIC:
+							let time_display = document.getElementById("time_display")
+							let tmin = document.getElementById("playbar_tmin")
+							let tmax = document.getElementById("playbar_tmax")
+							let zmin = document.getElementById("elevation_min")
+							let zmax = document.getElementById("elevation_max")
+
+							// Playbar Button Functions:
+							let playbutton = document.getElementById("playbutton")
+							let pausebutton = document.getElementById("pausebutton")
+							pausebutton.addEventListener("mousedown", () => {
+								animationEngine.stop()
+							})
+							playbutton.addEventListener("mousedown", () => {
+								animationEngine.start()
+							})
+
+							time_display.addEventListener('keyup', function onEvent(e) {
+								if (e.keyCode === 13) {
+									animationEngine.stop()
+									const newValue = parseFloat(time_display.value)
+									if (newValue) {
+										const newTime = Math.min(animationEngine.timeRange,
+											Math.max(0, newValue)) + animationInterval.start
+										setAnimationTime(newTime)
+									}
+								}
+							})
+
+							zmin.addEventListener("input", () => {
+								window.elevationWindow.min = Math.abs(Number(zmin.value))
+								window.elevationWindow.max = Math.abs(Number(zmax.value))
+								animationEngine.updateTimeForAll()
+							})
+
+							zmax.addEventListener("input", () => {
+								window.elevationWindow.min = Math.abs(Number(zmin.value))
+								window.elevationWindow.max = Math.abs(Number(zmax.value))
+								animationEngine.updateTimeForAll()
+							})
+						}
+					}
+				});
 
 
 			// RTK TweenTarget Callback:
 			window.updateCamera = true;
 			window.pitchThreshold = 1.00;
-			window.elevationWindow = {min: 1, max: 1, z: 0};
+			window.elevationWindow = { min: 1, max: 1, z: 0 };
 			animationEngine.tweenTargets.push((gpsTime) => {
-				try{
+				try {
 					let t = (gpsTime - animationEngine.tstart) / (animationEngine.timeRange);
 					let vehicle = viewer.scene.scene.getObjectByName("Vehicle");
 					let mesh = vehicle.getObjectByName("Vehicle Mesh");
@@ -788,11 +782,11 @@
 					// let elevationDeltaMin = -0;
 					// let elevationDeltaMax = 2;
 					let clouds = viewer.scene.pointclouds;
-					for (let ii=0, numClouds = clouds.length; ii<numClouds; ii++) {
-							let zheight = mesh.matrixWorld.getPosition().z;
-							window.elevationWindow.z = zheight;
-							viewer.scene.pointclouds[ii].material.elevationRange = [window.elevationWindow.z - window.elevationWindow.min, window.elevationWindow.z + window.elevationWindow.max];
-							// TODO set elevation slider range extent
+					for (let ii = 0, numClouds = clouds.length; ii < numClouds; ii++) {
+						let zheight = mesh.matrixWorld.getPosition().z;
+						window.elevationWindow.z = zheight;
+						viewer.scene.pointclouds[ii].material.elevationRange = [window.elevationWindow.z - window.elevationWindow.min, window.elevationWindow.z + window.elevationWindow.max];
+						// TODO set elevation slider range extent
 					}
 
 					// Save Current RTK Pose in Uniforms:
@@ -802,7 +796,7 @@
 						material.uniforms.currentRtkOrientation.value = state.orient.clone()
 					}
 				} catch (e) {
-					console.error("Caught error: ",e);
+					console.error("Caught error: ", e);
 				}
 			});
 		}
@@ -820,7 +814,7 @@
 				}
 			}
 
-			animationEngine.preStopCallback = function() {
+			animationEngine.preStopCallback = function () {
 				if (animationEngine.isPlaying) {
 					$("#pausebutton").trigger("mousedown");
 				}
@@ -834,10 +828,10 @@
 			// PointCloud:
 			animationEngine.tweenTargets.push((gpsTime) => {
 				// debugger; // account for pointcloud offset
-				let minGpsTime = gpsTime-animationEngine.activeWindow.backward;
-				let maxGpsTime = gpsTime+animationEngine.activeWindow.forward;
+				let minGpsTime = gpsTime - animationEngine.activeWindow.backward;
+				let maxGpsTime = gpsTime + animationEngine.activeWindow.forward;
 				viewer.setFilterGPSTimeRange(minGpsTime, maxGpsTime);
-				viewer.setFilterGPSTimeExtent(minGpsTime-1.5*animationEngine.activeWindow.backward, maxGpsTime+1.5*animationEngine.activeWindow.forward);
+				viewer.setFilterGPSTimeExtent(minGpsTime - 1.5 * animationEngine.activeWindow.backward, maxGpsTime + 1.5 * animationEngine.activeWindow.forward);
 			});
 
 			// Playbar:
@@ -868,61 +862,61 @@
 			});
 		}
 
-// Reload Lanes Button Code (Start)
-window.annotateLanesModeActive = false;
-$(document).ready(() => {
-	// Configure Playbar
-	$("#reload_lanes_button")[0].style.display="block"
-	let reloadLanesButton = $("#reload_lanes_button")[0];
-	reloadLanesButton.addEventListener("mousedown", () => {
+		// Reload Lanes Button Code (Start)
+		window.annotateLanesModeActive = false;
+		$(document).ready(() => {
+			// Configure Playbar
+			$("#reload_lanes_button")[0].style.display = "block"
+			let reloadLanesButton = $("#reload_lanes_button")[0];
+			reloadLanesButton.addEventListener("mousedown", () => {
 
-		let proceed = true;
-		if (window.annotateLanesModeActive) {
-			proceed = confirm("Proceed? Lanes will be reloaded, so ensure that annotations have been saved if you want to keep them.");
-		}
+				let proceed = true;
+				if (window.annotateLanesModeActive) {
+					proceed = confirm("Proceed? Lanes will be reloaded, so ensure that annotations have been saved if you want to keep them.");
+				}
 
-		if (proceed) {
-			// REMOVE LANES
-			let removeLanes = viewer.scene.scene.getChildByName("Lanes");
-			while(removeLanes) {
-				viewer.scene.scene.remove(removeLanes);
-				removeLanes = viewer.scene.scene.getChildByName("Lanes");
-			}
-
-			// Pause animation:
-			animationEngine.stop();
-
-			// TOGGLE window.annotateLanesModeActive
-			window.annotateLanesModeActive = !window.annotateLanesModeActive;
-
-			// Disable Button:
-			reloadLanesButton.disabled = true;
-
-			{
-				$("#loading-bar")[0].style.display = "none";
-				setLoadingScreen();
-				loadLanesCallback(s3, bucket, name, () => {
-					removeLoadingScreen();
-
-					// TOGGLE BUTTON TEXT
-					if (window.annotateLanesModeActive) {
-						reload_lanes_button.innerText = "View Truth Lanes";
-						document.getElementById("download_lanes_button").style.display = "block";
-					} else {
-						reload_lanes_button.innerText = "Annotate Truth Lanes";
-						document.getElementById("download_lanes_button").style.display = "none";
+				if (proceed) {
+					// REMOVE LANES
+					let removeLanes = viewer.scene.scene.getChildByName("Lanes");
+					while (removeLanes) {
+						viewer.scene.scene.remove(removeLanes);
+						removeLanes = viewer.scene.scene.getChildByName("Lanes");
 					}
 
-					reloadLanesButton.disabled = false
+					// Pause animation:
+					animationEngine.stop();
 
-				});
-			}
-		}
-	});
-});
-// Reload Lanes Button Code (end)
+					// TOGGLE window.annotateLanesModeActive
+					window.annotateLanesModeActive = !window.annotateLanesModeActive;
 
-// Load Lanes Code (start)
+					// Disable Button:
+					reloadLanesButton.disabled = true;
+
+					{
+						$("#loading-bar")[0].style.display = "none";
+						setLoadingScreen();
+						loadLanesCallback(s3, bucket, name, () => {
+							removeLoadingScreen();
+
+							// TOGGLE BUTTON TEXT
+							if (window.annotateLanesModeActive) {
+								reload_lanes_button.innerText = "View Truth Lanes";
+								document.getElementById("download_lanes_button").style.display = "block";
+							} else {
+								reload_lanes_button.innerText = "Annotate Truth Lanes";
+								document.getElementById("download_lanes_button").style.display = "none";
+							}
+
+							reloadLanesButton.disabled = false
+
+						});
+					}
+				}
+			});
+		});
+		// Reload Lanes Button Code (end)
+
+		// Load Lanes Code (start)
 		// Load Lanes Truth Data:
 		async function loadLanesCallback(s3, bucket, name, callback) {
 
@@ -933,7 +927,7 @@ $(document).ready(() => {
 				// need to have Annoted Lanes layer, so that can have original and edited lanes layers
 				let lanesLayer = new THREE.Group();
 				lanesLayer.name = "Lanes";
-				for (let ii=0, len=laneGeometries.all.length; ii<len; ii++) {
+				for (let ii = 0, len = laneGeometries.all.length; ii < len; ii++) {
 					lanesLayer.add(laneGeometries.all[ii]);
 				}
 				viewer.scene.scene.add(lanesLayer);
@@ -955,7 +949,7 @@ $(document).ready(() => {
 						await loadLanes(s3, bucket, name, filename, s, window.annotateLanesModeActive, viewer.scene.volumes, (laneGeometries) => {
 							let lanesLayer = new THREE.Group();
 							lanesLayer.name = layerName;
-							for (let ii=0, len=laneGeometries.all.length; ii<len; ii++) {
+							for (let ii = 0, len = laneGeometries.all.length; ii < len; ii++) {
 								lanesLayer.add(laneGeometries.all[ii]);
 							}
 							viewer.scene.scene.add(lanesLayer);
@@ -969,9 +963,9 @@ $(document).ready(() => {
 					}
 				};
 
-				const laneNum = [1,2,3];
+				const laneNum = [1, 2, 3];
 				const laneDirection = ["EB", "WB"];
-				const supplierNum = [1,2,3];
+				const supplierNum = [1, 2, 3];
 				let filename, layerName, datasetName;
 
 				for (let s of supplierNum) {
@@ -998,7 +992,7 @@ $(document).ready(() => {
 
 					let lanesLayer = new THREE.Group();
 					lanesLayer.name = `Lanes-${comparisonDatasets[0].split("Data/")[1]}`;
-					for (let ii=0, len=laneGeometries.all.length; ii<len; ii++) {
+					for (let ii = 0, len = laneGeometries.all.length; ii < len; ii++) {
 						lanesLayer.add(laneGeometries.all[ii]);
 					}
 					viewer.scene.scene.add(lanesLayer);
@@ -1011,83 +1005,83 @@ $(document).ready(() => {
 
 
 		}
-// Load Lanes Code (end)
+		// Load Lanes Code (end)
 
-// Load Gaps Code (Start)
-window.gapsLoaded = false;
-$(document).ready(() => {
-	// Configure Playbar
-	$("#load_gaps_button")[0].style.display="block"
-	let loadGapsButton = $("#load_gaps_button")[0];
-	loadGapsButton.addEventListener("mousedown", () => {
+		// Load Gaps Code (Start)
+		window.gapsLoaded = false;
+		$(document).ready(() => {
+			// Configure Playbar
+			$("#load_gaps_button")[0].style.display = "block"
+			let loadGapsButton = $("#load_gaps_button")[0];
+			loadGapsButton.addEventListener("mousedown", () => {
 
-		if (!window.gapsLoaded) {
-			$("#loading-bar")[0].style.display = "none";
-			setLoadingScreen();
+				if (!window.gapsLoaded) {
+					$("#loading-bar")[0].style.display = "none";
+					setLoadingScreen();
 
-			let gapShaderMaterial = shaderMaterial.clone();
-			gapShaderMaterial.uniforms.color.value = new THREE.Color(0x0000ff);
-			gapShaderMaterial.depthWrite = false;
-			loadGaps(s3, bucket, name, gapShaderMaterial, animationEngine, (gapGeometries) => {
-				let gapsLayer = new THREE.Group();
-				gapsLayer.name = "Vehicle Gaps";
-				for (let ii=0, len=gapGeometries.left.length; ii<len; ii++) {
-					// if (ii < 1000) {
-						gapsLayer.add(gapGeometries.left[ii]);
-					// }
+					let gapShaderMaterial = shaderMaterial.clone();
+					gapShaderMaterial.uniforms.color.value = new THREE.Color(0x0000ff);
+					gapShaderMaterial.depthWrite = false;
+					loadGaps(s3, bucket, name, gapShaderMaterial, animationEngine, (gapGeometries) => {
+						let gapsLayer = new THREE.Group();
+						gapsLayer.name = "Vehicle Gaps";
+						for (let ii = 0, len = gapGeometries.left.length; ii < len; ii++) {
+							// if (ii < 1000) {
+							gapsLayer.add(gapGeometries.left[ii]);
+							// }
+						}
+						viewer.scene.scene.add(gapsLayer);
+						viewer.scene.dispatchEvent({
+							"type": "assessments_layer_added",
+							"assessmentsLayer": gapsLayer
+						});
+						animationEngine.tweenTargets.push((gpsTime) => {
+							let currentTime = gpsTime - animationEngine.tstart;
+							gapShaderMaterial.uniforms.minGpsTime.value = currentTime - animationEngine.activeWindow.backward;
+							gapShaderMaterial.uniforms.maxGpsTime.value = currentTime + animationEngine.activeWindow.forward;
+						});
+						window.gapsLoaded = true;
+						loadGapsButton.disabled = true;
+						removeLoadingScreen();
+					});
 				}
-				viewer.scene.scene.add(gapsLayer);
+			});
+		});
+		// Load Gaps Code (end)
+
+		//load REM control points
+		// TODO Move this somewhere else
+
+		async function loadRemCallback(s3, bucket, name, animationEngine) {
+			let remShaderMaterial = shaderMaterial.clone();
+
+			await loadRem(s3, bucket, name, remShaderMaterial, animationEngine, (sphereMeshes) => {
+				let remLayer = new THREE.Group();
+				remLayer.name = "REM Control Points";
+				for (let ii = 0, len = sphereMeshes.length; ii < len; ii++) {
+					remLayer.add(sphereMeshes[ii]);
+				}
+
+				viewer.scene.scene.add(remLayer);
+				let e = new CustomEvent("truth_layer_added", { detail: remLayer, writable: true });
 				viewer.scene.dispatchEvent({
-					"type": "assessments_layer_added",
-					"assessmentsLayer": gapsLayer
+					"type": "sensor_layer_added",
+					"sensorLayer": remLayer
 				});
+
+				// TODO check if group works as expected, then trigger "truth_layer_added" event
 				animationEngine.tweenTargets.push((gpsTime) => {
 					let currentTime = gpsTime - animationEngine.tstart;
-					gapShaderMaterial.uniforms.minGpsTime.value = currentTime - animationEngine.activeWindow.backward;
-					gapShaderMaterial.uniforms.maxGpsTime.value = currentTime + animationEngine.activeWindow.forward;
+					remShaderMaterial.uniforms.minGpsTime.value = currentTime - animationEngine.activeWindow.backward;
+					remShaderMaterial.uniforms.maxGpsTime.value = currentTime + animationEngine.activeWindow.forward;
 				});
-				window.gapsLoaded = true;
-				loadGapsButton.disabled = true;
-				removeLoadingScreen();
 			});
 		}
-	});
-});
-// Load Gaps Code (end)
-
-//load REM control points
-// TODO Move this somewhere else
-
-async function loadRemCallback(s3, bucket, name, animationEngine) {
-	let remShaderMaterial = shaderMaterial.clone();
-
-	await loadRem(s3, bucket, name, remShaderMaterial, animationEngine, (sphereMeshes) => {
-		let remLayer = new THREE.Group();
-		remLayer.name = "REM Control Points";
-		for (let ii=0, len=sphereMeshes.length; ii<len; ii++) {
-			remLayer.add(sphereMeshes[ii]);
-		}
-
-		viewer.scene.scene.add(remLayer);
-		let e = new CustomEvent("truth_layer_added", {detail: remLayer, writable: true});
-		viewer.scene.dispatchEvent({
-			"type": "sensor_layer_added",
-			"sensorLayer": remLayer
-		});
-
-		// TODO check if group works as expected, then trigger "truth_layer_added" event
-		animationEngine.tweenTargets.push((gpsTime) => {
-			let currentTime = gpsTime - animationEngine.tstart;
-			remShaderMaterial.uniforms.minGpsTime.value = currentTime - animationEngine.activeWindow.backward;
-			remShaderMaterial.uniforms.maxGpsTime.value = currentTime + animationEngine.activeWindow.forward;
-		});
-	});
-}
 
 
 
 
-// Load Tracks Code (Start)
+		// Load Tracks Code (Start)
 		// TODO Move this somewhere else
 		let trackShaderMaterial = shaderMaterial.clone();
 
@@ -1096,13 +1090,13 @@ async function loadRemCallback(s3, bucket, name, animationEngine) {
 			await loadTracks(s3, bucket, name, trackShaderMaterial, animationEngine, (trackGeometries) => {
 				let trackLayer = new THREE.Group();
 				trackLayer.name = "Tracked Objects";
-				for (let ii=0, len=trackGeometries.bbox.length; ii<len; ii++) {
+				for (let ii = 0, len = trackGeometries.bbox.length; ii < len; ii++) {
 					trackLayer.add(trackGeometries.bbox[ii]);
 					// viewer.scene.scene.add(trackGeometries.bbox[ii]); // Original
 				}
 
 				viewer.scene.scene.add(trackLayer);
-				let e = new CustomEvent("truth_layer_added", {detail: trackLayer, writable: true});
+				let e = new CustomEvent("truth_layer_added", { detail: trackLayer, writable: true });
 				viewer.scene.dispatchEvent({
 					"type": "truth_layer_added",
 					"truthLayer": trackLayer
@@ -1122,7 +1116,7 @@ async function loadRemCallback(s3, bucket, name, animationEngine) {
 		window.detectionsLoaded = false;
 		$(document).ready(() => {
 			// Configure Playbar
-			$("#load_detections_button")[0].style.display="block"
+			$("#load_detections_button")[0].style.display = "block"
 			let loadDetectionsButton = $("#load_detections_button")[0];
 			loadDetectionsButton.addEventListener("mousedown", () => {
 				if (!window.detectionsLoaded) {
@@ -1133,7 +1127,7 @@ async function loadRemCallback(s3, bucket, name, animationEngine) {
 					loadDetections(s3, bucket, name, detectionShaderMaterial, animationEngine, (detectionGeometries) => {
 						let detectionLayer = new THREE.Group();
 						detectionLayer.name = "Object Detections";
-						for (let ii=0, len=detectionGeometries.bbox.length; ii<len; ii++) {
+						for (let ii = 0, len = detectionGeometries.bbox.length; ii < len; ii++) {
 							detectionLayer.add(detectionGeometries.bbox[ii]);
 						}
 						viewer.scene.scene.add(detectionLayer);
@@ -1155,83 +1149,83 @@ async function loadRemCallback(s3, bucket, name, animationEngine) {
 		});
 
 
-// Load Tracks Code (End)
+		// Load Tracks Code (End)
 
-    // // Load Radar Cubes:
-    // loadRadar((geometry, t_init) => {
+		// // Load Radar Cubes:
+		// loadRadar((geometry, t_init) => {
 		//
-    //   // uniforms
-    //   uniforms = {
-    //       color: { value: new THREE.Color( 0xffff00 ) },
-    //       minGpsTime: {value: 0.0 },
-    //       maxGpsTime: {value: 110.0 },
-    //       initialTime: {value: t_init}
-    //   };
+		//   // uniforms
+		//   uniforms = {
+		//       color: { value: new THREE.Color( 0xffff00 ) },
+		//       minGpsTime: {value: 0.0 },
+		//       maxGpsTime: {value: 110.0 },
+		//       initialTime: {value: t_init}
+		//   };
 		//
-    //   // point cloud material
-    //   var shaderMaterial = new THREE.ShaderMaterial( {
+		//   // point cloud material
+		//   var shaderMaterial = new THREE.ShaderMaterial( {
 		//
-    //       uniforms:       uniforms,
-    //       vertexShader:   document.getElementById( 'vertexshader' ).textContent,
-    //       fragmentShader: document.getElementById( 'fragmentshader' ).textContent,
-    //       transparent:    true
+		//       uniforms:       uniforms,
+		//       vertexShader:   document.getElementById( 'vertexshader' ).textContent,
+		//       fragmentShader: document.getElementById( 'fragmentshader' ).textContent,
+		//       transparent:    true
 		//
-    //   });
+		//   });
 		//
-    //   var material = new THREE.PointsMaterial( {size:1.0} );
-    //   var mesh = new THREE.Points(geometry, shaderMaterial);
-    //   mesh.name = "radar";
-    //   // debugger; //radar tracks added?
-    //   viewer.scene.scene.add(mesh);
-    // });
+		//   var material = new THREE.PointsMaterial( {size:1.0} );
+		//   var mesh = new THREE.Points(geometry, shaderMaterial);
+		//   mesh.name = "radar";
+		//   // debugger; //radar tracks added?
+		//   viewer.scene.scene.add(mesh);
+		// });
 
-// Load Radar Code (Start)
+		// Load Radar Code (Start)
 		window.radarLoaded = false;
 		$(document).ready(() => {
 			// Configure Playbar
-			$("#load_radar_button")[0].style.display="block"
+			$("#load_radar_button")[0].style.display = "block"
 			let loadRadarButton = $("#load_radar_button")[0];
 			loadRadarButton.addEventListener("mousedown", () => {
 				if (!window.radarLoaded) {
 					$("#loading-bar")[0].style.display = "none";
 					setLoadingScreen();
 
-					loadRadar(s3, bucket, name, (geometry,t_init, boxBufferGeometries) => {
+					loadRadar(s3, bucket, name, (geometry, t_init, boxBufferGeometries) => {
 
-						let boxMesh = new THREE.Mesh(boxBufferGeometries, new THREE.MeshBasicMaterial({color: 0xffff00}) );
+						let boxMesh = new THREE.Mesh(boxBufferGeometries, new THREE.MeshBasicMaterial({ color: 0xffff00 }));
 						boxMesh.name = "radar_boxes";
 						// viewer.scene.scene.add(boxMesh);
 
 
 						// uniforms
 						let uniforms = {
-								color: { value: new THREE.Color( 0xffff00 ) },
-								minGpsTime: {value: 0.0 },
-								maxGpsTime: {value: 110.0 },
-								initialTime: {value: t_init}
+							color: { value: new THREE.Color(0xffff00) },
+							minGpsTime: { value: 0.0 },
+							maxGpsTime: { value: 110.0 },
+							initialTime: { value: t_init }
 						};
 
 						// point cloud material
-						var shaderMaterial = new THREE.ShaderMaterial( {
+						var shaderMaterial = new THREE.ShaderMaterial({
 
-								uniforms:       uniforms,
-								vertexShader:   document.getElementById( 'vertexshader' ).textContent,
-								fragmentShader: document.getElementById( 'fragmentshader' ).textContent,
-								transparent:    true
+							uniforms: uniforms,
+							vertexShader: document.getElementById('vertexshader').textContent,
+							fragmentShader: document.getElementById('fragmentshader').textContent,
+							transparent: true
 
 						});
 
-						var material = new THREE.PointsMaterial( {size:1.0} );
+						var material = new THREE.PointsMaterial({ size: 1.0 });
 						var mesh = new THREE.Points(geometry, shaderMaterial);
 						mesh.name = "radar";
 						// debugger; //radar tracks added?
 						viewer.scene.scene.add(mesh);
-						viewer.scene.dispatchEvent({"type": "sensor_layer_added", "sensorLayer": mesh });
+						viewer.scene.dispatchEvent({ "type": "sensor_layer_added", "sensorLayer": mesh });
 
 
 						// Create tween:
 						{
-							animationEngine.tweenTargets.push( (t) => {
+							animationEngine.tweenTargets.push((t) => {
 								// debugger;
 								let minGpsTime = t - animationEngine.activeWindow.backward;
 								let maxGpsTime = t + animationEngine.activeWindow.forward;
@@ -1271,14 +1265,14 @@ async function loadRemCallback(s3, bucket, name, animationEngine) {
 					vehicleMesh.rotation.set(rtk2Vehicle.roll, rtk2Vehicle.pitch, rtk2Vehicle.yaw);
 
 					// Store updated values in mesh:
-					material.uniforms.rtk2VehicleXYZNew = {type: "v3", value: new THREE.Vector3(rtk2Vehicle.x, rtk2Vehicle.y, rtk2Vehicle.z)};
-					material.uniforms.rtk2VehicleRPYNew = {type: "v3", value: new THREE.Vector3(rtk2Vehicle.roll, rtk2Vehicle.pitch, rtk2Vehicle.yaw)};
+					material.uniforms.rtk2VehicleXYZNew = { type: "v3", value: new THREE.Vector3(rtk2Vehicle.x, rtk2Vehicle.y, rtk2Vehicle.z) };
+					material.uniforms.rtk2VehicleRPYNew = { type: "v3", value: new THREE.Vector3(rtk2Vehicle.roll, rtk2Vehicle.pitch, rtk2Vehicle.yaw) };
 
 				} else if (id == "velo2rtk") {
 
 					let velo2Rtk = getVelo2Rtk();
-					material.uniforms.velo2RtkXYZNew = {type: "v3", value: new THREE.Vector3(velo2Rtk.x, velo2Rtk.y, velo2Rtk.z)};
-					material.uniforms.velo2RtkRPYNew = {type: "v3", value: new THREE.Vector3(velo2Rtk.roll, velo2Rtk.pitch, velo2Rtk.yaw)};
+					material.uniforms.velo2RtkXYZNew = { type: "v3", value: new THREE.Vector3(velo2Rtk.x, velo2Rtk.y, velo2Rtk.z) };
+					material.uniforms.velo2RtkRPYNew = { type: "v3", value: new THREE.Vector3(velo2Rtk.roll, velo2Rtk.pitch, velo2Rtk.yaw) };
 
 				} else {
 					console.error("Unknown Calibration Extrinsics Id:", id);
@@ -1289,12 +1283,12 @@ async function loadRemCallback(s3, bucket, name, animationEngine) {
 		window.canEnableCalibrationPanels = true;
 		function canUseCalibrationPanels(attributes) {
 			let hasRtkPose = false;
-      		let hasRtkOrient = false;
-      		for (let attr of attributes) {
-      			hasRtkPose = hasRtkPose || (attr.name === PointAttributeNames.RTK_POSE);
-      			hasRtkOrient = hasRtkOrient || (attr.name === PointAttributeNames.RTK_ORIENT);
-      		}
-      		return hasRtkPose && hasRtkOrient
+			let hasRtkOrient = false;
+			for (let attr of attributes) {
+				hasRtkPose = hasRtkPose || (attr.name === PointAttributeNames.RTK_POSE);
+				hasRtkOrient = hasRtkOrient || (attr.name === PointAttributeNames.RTK_ORIENT);
+			}
+			return hasRtkPose && hasRtkOrient
 		}
 
 		// Load Pointclouds
@@ -1302,61 +1296,62 @@ async function loadRemCallback(s3, bucket, name, animationEngine) {
 			Potree.loadPointCloud("../pointclouds/test/cloud.js", "full-cloud", e => {
 				const pointcloud = e.pointcloud;
 				const material = pointcloud.material;
-	      		viewer.scene.addPointCloud(pointcloud);
-	      		material.pointColorType = Potree.PointColorType.INTENSITY; // any Potree.PointColorType.XXXX
+				viewer.scene.addPointCloud(pointcloud);
+				material.pointColorType = Potree.PointColorType.INTENSITY; // any Potree.PointColorType.XXXX
 				material.gradient = Potree.Gradients.GRAYSCALE; // Can define custom gradient or look up in Potree.Gradients
-	      		material.size = 0.09;
-	      		material.pointSizeType = Potree.PointSizeType.ADAPTIVE;
-	      		material.shape = Potree.PointShape.SQUARE;
+				material.size = 0.09;
+				material.pointSizeType = Potree.PointSizeType.ADAPTIVE;
+				material.shape = Potree.PointShape.SQUARE;
 
-	      		let cloudCanUseCalibrationPanels = canUseCalibrationPanels(pointcloud.pcoGeometry.pointAttributes.attributes);
-	      		window.canEnableCalibrationPanels = window.canEnableCalibrationPanels && cloudCanUseCalibrationPanels;
+				let cloudCanUseCalibrationPanels = canUseCalibrationPanels(pointcloud.pcoGeometry.pointAttributes.attributes);
+				window.canEnableCalibrationPanels = window.canEnableCalibrationPanels && cloudCanUseCalibrationPanels;
 
-	      		if (window.canEnableCalibrationPanels) {
-	      			$(document).ready(() => enablePanels() );
+				if (window.canEnableCalibrationPanels) {
+					$(document).ready(() => enablePanels());
 
-	      		} else {
-	      			$(document).ready(() => {
-	      				let reason = "Pointcloud was not serialized with the necessary point attributes"
-	      				disablePanels(reason);
-	      				console.error("Cannot use calibration panels: ", reason);
-	      			});
-	      		}
+				} else {
+					$(document).ready(() => {
+						let reason = "Pointcloud was not serialized with the necessary point attributes"
+						disablePanels(reason);
+						console.error("Cannot use calibration panels: ", reason);
+					});
+				}
 			});
 
-	    } else {
-        	Potree.loadPointCloud({s3, bucket, name}, name.substring(5), e => {
-		    	const pointcloud = e.pointcloud;
-			    const material = pointcloud.material;
-			    viewer.scene.addPointCloud(pointcloud);
-			    material.pointColorType = Potree.PointColorType.INTENSITY; // any Potree.PointColorType.XXXX
+		} else {
+			Potree.loadPointCloud({ s3, bucket, name }, name.substring(5), e => {
+				const pointcloud = e.pointcloud;
+				const material = pointcloud.material;
+				viewer.scene.addPointCloud(pointcloud);
+				material.pointColorType = Potree.PointColorType.INTENSITY; // any Potree.PointColorType.XXXX
 				material.gradient = Potree.Gradients.GRAYSCALE;
-			    material.size = 0.09;
-			    material.pointSizeType = Potree.PointSizeType.ADAPTIVE;
-			    material.shape = Potree.PointShape.SQUARE;
+				material.size = 0.09;
+				material.pointSizeType = Potree.PointSizeType.ADAPTIVE;
+				material.shape = Potree.PointShape.SQUARE;
 
-	      		let cloudCanUseCalibrationPanels = canUseCalibrationPanels(pointcloud.pcoGeometry.pointAttributes.attributes);
-	      		window.canEnableCalibrationPanels = window.canEnableCalibrationPanels && cloudCanUseCalibrationPanels;
+				let cloudCanUseCalibrationPanels = canUseCalibrationPanels(pointcloud.pcoGeometry.pointAttributes.attributes);
+				window.canEnableCalibrationPanels = window.canEnableCalibrationPanels && cloudCanUseCalibrationPanels;
 
-	      		if (window.canEnableCalibrationPanels) {
-	      			$(document).ready(() => enablePanels() );
+				if (window.canEnableCalibrationPanels) {
+					$(document).ready(() => enablePanels());
 
-	      		} else {
-	      			$(document).ready(() => {
-	      				disablePanels("Pointcloud was not serialized with the necessary point attributes");
-	      				console.error("Cannot use calibration panels");
-	      			});
-	      		}
+				} else {
+					$(document).ready(() => {
+						disablePanels("Pointcloud was not serialized with the necessary point attributes");
+						console.error("Cannot use calibration panels");
+					});
+				}
 
-	      		$("#playbutton").click();
+				$("#playbutton").click();
 
 				try {
 					togglePointClass(pointcloud);
 				} catch (e) {
 					console.log("Pointcloud loaded before sidebar initialized: ", e);
 				}
-		    });
-      }
-		</script>
-  </body>
+			});
+		}
+	</script>
+</body>
+
 </html>

--- a/demo/radar.html
+++ b/demo/radar.html
@@ -168,6 +168,9 @@
 			}
 		}
 
+		const minAnimationStepDigits = 5
+		const minAnimationStep = Math.pow(10, -minAnimationStepDigits)
+
 		// setLoadingScreen();
 
 		const runForLocalDevelopment = location.search === "" &&
@@ -184,8 +187,6 @@
 		const downloadLanesAvailable = annotateLanesAvailable
 		const calibrationModeAvailable = params.get("calibrate") == "Calibrate" ||
 				runForLocalDevelopment
-		let customTimeInterval = decanonicalizeTimeInterval(
-				[params.get("start"), params.get("end")])
 		const accessKeyId = params.get("key1")
 		const secretAccessKey = params.get("key2")
 		const sessionToken = params.get("key3")
@@ -195,6 +196,9 @@
 		if (names) {
 			comparisonDatasets = names.filter(element => element !== name)
 		}
+		let customLocalInterval = decanonicalizeTimeInterval(
+				[params.get("start"), params.get("end")])
+		let animationInterval = null
 
 		if (fonts) {
 			const head = document.head
@@ -260,8 +264,6 @@
 				viewer.setCameraMode(Potree.CameraMode.ORTHOGRAPHIC);
 				viewer.scene.view.maxPitch = -Math.PI/2;
 
-				document.getElementById("playback_speed").style.display = "none";
-				document.getElementById("toggleslider").style.display = "none";
 				document.getElementById("toggle_calibration_panels").style.display = "none";
 				document.getElementById("load_detections_button").style.display = "none";
 				document.getElementById("load_radar_button").style.display = "none";
@@ -310,8 +312,6 @@
 
 		})
 
-		let isShiftKeyDown = false
-
 		// Playbar Configuration:
 		$(document).ready(() => {
 			document.getElementById("playbar_tmax").disabled = false
@@ -327,9 +327,6 @@
 			div.style.opacity = 0
 
 			window.addEventListener('keydown', (e) => {
-				if (e.shiftKey) {
-					isShiftKeyDown = true
-				}
 				if (window.annotateLanesModeActive) {
 					if (e.code == "KeyA") {
 						window.truthAnnotationMode = 2
@@ -358,9 +355,6 @@
 			});
 
 			window.addEventListener("keyup", (e) => {
-				if (e.shiftKey) {
-					isShiftKeyDown = false
-				}
 				if (window.annotateLanesModeActive) {
 					window.truthAnnotationMode = 0
 					let div = document.getElementById("annotationScreen")
@@ -450,26 +444,99 @@
 
 		}); // END $(document).ready()
 
-		window.addEventListener("message", ({data}) => {
-			if (data.type === "updateTimeInterval") {
-				customTimeInterval = decanonicalizeTimeInterval(data.timeInterval)
-				relaunchAnimationWithNewInterval()
+		window.addEventListener("message", ({origin, data}) => {
+			if (data.type === "updateTimeInterval" && origin !== window.origin) {
+				animationInterval = decanonicalizeTimeInterval(data.timeInterval)
+				relaunchWithNewInterval()
 			}
 		}, false)
 
+		function updateTimeDisplay(newTime) {
+			document.getElementById("time_display").value =
+					(newTime - animationInterval.start).toFixed(minAnimationStepDigits)
+			document.getElementById("full_time_display").value =
+					(newTime - window.fullTimeInterval.start).toFixed(
+							minAnimationStepDigits)
+		}
+
+		function setAnimationTime(newTime) {
+			animationEngine.stop()
+			animationEngine.timeline.t = newTime
+			animationEngine.updateTimeForAll()
+		}
+
+		function setAnimationInterval(newAnimationInterval) {
+			animationInterval = newAnimationInterval
+
+			const timeSlider = $("#timeSlider")
+			timeSlider.slider("option", "min", animationInterval.start)
+			timeSlider.slider("option", "max", animationInterval.end)
+
+			if (animationEngine.timeline.t < animationInterval.start ||
+					animationEngine.timeline.t > animationInterval.end) {
+				relaunchWithNewInterval() // also calls animationEngine.stop()
+			} else {
+				animationEngine.stop()
+				timeSlider.slider("value", animationEngine.timeline.t)
+				updateTimeDisplay(animationEngine.timeline.t)
+			}
+
+			window.parent.postMessage({
+				type: "updateTimeInterval",
+				timeInterval: canonicalizeTimeInterval(animationInterval)
+			}, "*")
+		}
+
+		// Called when we get the full animation interval to set up sliders and other stuff
+		function setupFullTimeInterval(fullTimeInterval) {
+			window.fullTimeInterval = fullTimeInterval
+
+			animationInterval = {
+				start: customLocalInterval ?
+						(fullTimeInterval.start + customLocalInterval.start) :
+						fullTimeInterval.start,
+				end: customLocalInterval ?
+						(fullTimeInterval.start + customLocalInterval.end) :
+						fullTimeInterval.end
+			}
+
+			$("#intervalSlider").slider({
+				range: true,
+				min: fullTimeInterval.start,
+				max: fullTimeInterval.end,
+				values: [animationInterval.start, animationInterval.end],
+				step: minAnimationStep,
+				slide: (event, ui) => {
+					setAnimationInterval({start: ui.values[0], end: ui.values[1]})
+				}
+			})
+
+			$("#timeSlider").slider({
+				min: animationInterval.start,
+				max: animationInterval.end,
+				value: animationInterval.start,
+				step: minAnimationStep,
+				slide: (event, ui) => {
+					setAnimationTime(ui.value)
+				}
+			})
+
+			updateTimeDisplay(animationInterval.start)
+		}
+
 		function launchAnimationWithNewInterval() {
-			const tstart = customTimeInterval ?
-					(window.fullTimeInterval.start + customTimeInterval.start) :
-					window.fullTimeInterval.start
-			const tend = customTimeInterval ?
-					(window.fullTimeInterval.start + customTimeInterval.end) :
-					window.fullTimeInterval.end
 			const playbackRate = 1.0
-			animationEngine.configure(tstart, tend, playbackRate)
+			animationEngine.configure(animationInterval.start, animationInterval.end,
+					playbackRate)
 			animationEngine.launch()
 		}
 
-		function relaunchAnimationWithNewInterval() {
+		function updateIntervalSlider() {
+			$("#intervalSlider")
+					.slider("values", animationInterval.start, animationInterval.end)
+		}
+
+		function relaunchWithNewInterval() {
 			launchAnimationWithNewInterval()
 			animationEngine.updateTimeForAll()
 		}
@@ -479,9 +546,7 @@
 			// loadRtk(s3, bucket, name, (pos, rot, timestamps, t_init, t_range) => {
 			loadRtkFlatbuffer(s3, bucket, name,
 					(pos, rot, timestamps, t_init, t_range) => {
-						window.fullTimeInterval = {
-							start: t_init, end: t_init + t_range
-						}
+						setupFullTimeInterval({start: t_init, end: t_init + t_range})
 
 						// TODO Move this into main loader function:
 						launchAnimationWithNewInterval()
@@ -632,98 +697,51 @@
 										viewer.setFilterGPSTimeRange(0, 0) // Size 0 Time Window at start of timeline
 										removeLoadingScreen()
 									}, onProgress, onError)
-	      }
-
-	      // ANIMATION:
-	      { // create Animation Path & make light follow it
-	        {// ANIMATION + SLIDER LOGIC:
-	          let slider = document.getElementById("myRange");
-	          let time_display = document.getElementById("time_display");
-						let tmin = document.getElementById("playbar_tmin");
-						let tmax = document.getElementById("playbar_tmax");
-						let zmin = document.getElementById("elevation_min");
-						let zmax = document.getElementById("elevation_max");
-	          time_display.value = Math.round(10000*slider.value)/10000;
-
-	          // Playbar Button Functions:
-	          let playbutton = document.getElementById("playbutton");
-	          let pausebutton = document.getElementById("pausebutton");
-	          pausebutton.addEventListener("mousedown", () => {
-							animationEngine.stop();
-	          });
-	          playbutton.addEventListener("mousedown", () => {
-							animationEngine.start();
-	          });
-
-						time_display.addEventListener('keyup', function onEvent(e) {
-					    if (e.keyCode === 13) {
-					        console.log('Enter')
-									animationEngine.stop();
-									let val = parseFloat(time_display.value);
-									val = Math.max(0, val);
-									val = Math.min(animationEngine.timeRange-.001, val);
-									animationEngine.timeline.t = val + animationEngine.tstart;
-									animationEngine.updateTimeForAll();
-					    }
-						});
-
-						slider.addEventListener("input", () => {
-							animationEngine.stop();
-							var val = slider.value/100.0;
-							animationEngine.timeline.t = val*animationEngine.timeRange + animationEngine.tstart;
-							animationEngine.updateTimeForAll();
-						});
-
-						slider.addEventListener("wheel", () => {
-							animationEngine.stop()
-							var val = slider.value / 100.0
-							animationEngine.timeline.t =
-									val * animationEngine.timeRange + animationEngine.tstart
-							animationEngine.updateTimeForAll()
-						});
-
-						zmin.addEventListener("input", () => {
-							window.elevationWindow.min = Math.abs(Number(zmin.value))
-							window.elevationWindow.max = Math.abs(Number(zmax.value))
-							animationEngine.updateTimeForAll()
-						})
-
-						zmax.addEventListener("input", () => {
-							window.elevationWindow.min = Math.abs(Number(zmin.value))
-							window.elevationWindow.max = Math.abs(Number(zmax.value))
-							animationEngine.updateTimeForAll()
-						})
-
-						// Adjust time interval by shift-clicking and dragging a range
-						function getSliderTimeForInterval() {
-							return (slider.value / 100.0 * animationEngine.timeRange) +
-									animationEngine.tstart - window.fullTimeInterval.start
 						}
 
-						let newTimeIntervalStart = null
+						// ANIMATION:
+						{ // create Animation Path & make light follow it
+							{// ANIMATION + SLIDER LOGIC:
+								let time_display = document.getElementById("time_display")
+								let tmin = document.getElementById("playbar_tmin")
+								let tmax = document.getElementById("playbar_tmax")
+								let zmin = document.getElementById("elevation_min")
+								let zmax = document.getElementById("elevation_max")
 
-						slider.addEventListener("mousedown", () => {
-							if (isShiftKeyDown) {
-								newTimeIntervalStart = getSliderTimeForInterval()
+								// Playbar Button Functions:
+								let playbutton = document.getElementById("playbutton")
+								let pausebutton = document.getElementById("pausebutton")
+								pausebutton.addEventListener("mousedown", () => {
+									animationEngine.stop()
+								})
+								playbutton.addEventListener("mousedown", () => {
+									animationEngine.start()
+								})
+
+								time_display.addEventListener('keyup', function onEvent(e) {
+									if (e.keyCode === 13) {
+										animationEngine.stop()
+										const newValue = parseFloat(time_display.value)
+										if (newValue) {
+											const newTime = Math.min(animationEngine.timeRange,
+													Math.max(0, newValue)) + animationInterval.start
+											setAnimationTime(newTime)
+										}
+									}
+								})
+
+								zmin.addEventListener("input", () => {
+									window.elevationWindow.min = Math.abs(Number(zmin.value))
+									window.elevationWindow.max = Math.abs(Number(zmax.value))
+									animationEngine.updateTimeForAll()
+								})
+
+								zmax.addEventListener("input", () => {
+									window.elevationWindow.min = Math.abs(Number(zmin.value))
+									window.elevationWindow.max = Math.abs(Number(zmax.value))
+									animationEngine.updateTimeForAll()
+								})
 							}
-						})
-
-						slider.addEventListener("mouseup", () => {
-							if (isShiftKeyDown && newTimeIntervalStart) {
-								const newTimeIntervalEnd = getSliderTimeForInterval()
-								customTimeInterval =
-										{start: newTimeIntervalStart, end: newTimeIntervalEnd}
-								window.parent.postMessage({
-									type: "updateTimeInterval",
-									timeInterval: canonicalizeTimeInterval(customTimeInterval)
-								}, "*")
-								relaunchAnimationWithNewInterval()
-							} else {
-								newTimeIntervalStart = null
-							}
-						})
-					}
-
 	      }
 	    });
 
@@ -779,9 +797,9 @@
 
 					// Save Current RTK Pose in Uniforms:
 					for (let ii = 0, numClouds = clouds.length; ii < numClouds; ii++) {
-						let material = clouds[ii].material;
-						material.uniforms.currentRtkPosition.value = state.pose.clone();
-						material.uniforms.currentRtkOrientation.value = state.orient.toVector3().clone();
+						let material = clouds[ii].material
+						material.uniforms.currentRtkPosition.value = state.pose.clone()
+						material.uniforms.currentRtkOrientation.value = state.orient.clone()
 					}
 				} catch (e) {
 					console.error("Caught error: ",e);
@@ -824,17 +842,8 @@
 
 			// Playbar:
 			animationEngine.tweenTargets.push((gpsTime) => {
-				let slider = document.getElementById("myRange");
-				let time_display = document.getElementById("time_display");
-				let tmin = document.getElementById("playbar_tmin");
-				let tmax = document.getElementById("playbar_tmax");
-				let toggleplay = document.getElementById("toggleplay");
-				// TODO add playbackSpeed
-				time_display.value = Math.round(10000*slider.value)/10000;
-
-				let t = (gpsTime - animationEngine.tstart) / (animationEngine.timeRange);
-				slider.value = 100*t;
-				time_display.value = Math.round(10000*(gpsTime - animationEngine.tstart))/10000; // Centered to zero
+				$("#timeSlider").slider("value", gpsTime)
+				updateTimeDisplay(gpsTime)
 			});
 
 			// // Camera:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,7 +105,7 @@ gulp.task("build", ['workers','shaders', "icons_viewer", "examples_page"], funct
 // For development, it is now possible to use 'gulp webserver'
 // from the command line to start the server (default port is 8080)
 gulp.task('webserver', function() {
-	server = connect.server({host: '0.0.0.0', port: 1234});
+	server = connect.server({host: '0.0.0.0', port: 1234})
 });
 
 gulp.task('examples_page', function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -911,7 +911,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -929,11 +930,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -946,15 +949,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1057,7 +1063,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1067,6 +1074,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1079,17 +1087,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1106,6 +1117,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1178,7 +1190,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1188,6 +1201,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1263,7 +1277,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1293,6 +1308,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1310,6 +1326,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1348,11 +1365,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
The visualize component now shows only the selected interval. The interval start/end is the slider start/end, so the animation won't go past. A user can tell an interval is selected because it says to on the Veritas app bar

Also, you can change the interval inside POTree by shift-clicking and dragging a smaller interval on the slider. Currently you can't select a bigger interval, you must go into EvaluateComponent (maybe add a "zoom out" option later). When the visualize interval changes, it will also change the evaluate interval.

Also see https://github.com/NextDroid/VeritasApplication/pull/395