### PR TITLE
Revert "Finishes 'bcassels/better-names' - see PR #119 for approvals"

### DIFF
--- a/src/loader/BinaryLoader.js
+++ b/src/loader/BinaryLoader.js
@@ -95,9 +95,9 @@ export class BinaryLoader{
 						offset: buffers[property].offset,
 						range: buffers[property].range,
 					};
-				} else if (parseInt(property) === PointAttributeNames.RTK_POSITION) {
+				} else if (parseInt(property) === PointAttributeNames.RTK_POSE) {
 					geometry.addAttribute('originalRtkPosition', new THREE.BufferAttribute(new Float32Array(buffer), 3, false));
-				} else if (parseInt(property) === PointAttributeNames.RTK_ORIENTATION) {
+				} else if (parseInt(property) === PointAttributeNames.RTK_ORIENT) {
 					geometry.addAttribute('originalRtkOrientation', new THREE.BufferAttribute(new Float32Array(buffer), 3, false));
 				}
 			}

--- a/src/loader/PointAttributes.js
+++ b/src/loader/PointAttributes.js
@@ -18,8 +18,8 @@ export const PointAttributeNames = {
 	INDICES: 14,
 	SPACING: 15,
 	GPS_TIME: 16,
-	RTK_POSITION: 17,
-	RTK_ORIENTATION: 18,
+	RTK_POSE: 17,
+	RTK_ORIENT: 18,
 };
 
 
@@ -127,12 +127,12 @@ PointAttribute.GPS_TIME = new PointAttribute(
 	PointAttributeNames.GPS_TIME,
 	PointAttributeTypes.DATA_TYPE_DOUBLE, 1);
 
-PointAttribute.RTK_POSITION = new PointAttribute(
-	PointAttributeNames.RTK_POSITION,
+PointAttribute.RTK_POSE = new PointAttribute(
+	PointAttributeNames.RTK_POSE,
 	PointAttributeTypes.DATA_TYPE_DOUBLE, 3);
 
-PointAttribute.RTK_ORIENTATION = new PointAttribute(
-	PointAttributeNames.RTK_ORIENTATION,
+PointAttribute.RTK_ORIENT = new PointAttribute(
+	PointAttributeNames.RTK_ORIENT,
 	PointAttributeTypes.DATA_TYPE_DOUBLE, 3);
 
 export {PointAttribute};

--- a/src/workers/BinaryDecoderWorker.js
+++ b/src/workers/BinaryDecoderWorker.js
@@ -135,9 +135,9 @@ onmessage = function (event) {
 			}
 
 			attributeBuffers[pointAttribute.name] = { buffer: buff, attribute: pointAttribute };
-		} else if (pointAttribute.name === PointAttribute.RTK_POSITION.name) {
+		} else if (pointAttribute.name === PointAttribute.RTK_POSE.name) {
 			let buff = new ArrayBuffer(numPoints * 4 * 3);
-			let rtk_positions = new Float32Array(buff);
+			let rtk_poses = new Float32Array(buff);
 			let view = new DataView(buffer);
 
 			for (let j = 0; j < numPoints; j++) {
@@ -145,24 +145,24 @@ onmessage = function (event) {
 				y = view.getFloat64(inOffset + j * pointAttributes.byteSize + 8, true);
 				z = view.getFloat64(inOffset + j * pointAttributes.byteSize + 16, true);
 
-				rtk_positions[3 * j + 0] = x;
-				rtk_positions[3 * j + 1] = y;
-				rtk_positions[3 * j + 2] = z;
+				rtk_poses[3 * j + 0] = x;
+				rtk_poses[3 * j + 1] = y;
+				rtk_poses[3 * j + 2] = z;
 			}
 
 			attributeBuffers[pointAttribute.name] = { buffer: buff, attribute: pointAttribute };
-		} else if (pointAttribute.name === PointAttribute.RTK_ORIENTATION.name) {
+		} else if (pointAttribute.name === PointAttribute.RTK_ORIENT.name) {
 			let buff = new ArrayBuffer(numPoints * 4 * 3);
-			let rtk_orientations = new Float32Array(buff);
+			let rtk_orients = new Float32Array(buff);
 
 			for (let j = 0; j < numPoints; j++) {
 				x = cv.getFloat64(inOffset + j * pointAttributes.byteSize + 0, true);
 				y = cv.getFloat64(inOffset + j * pointAttributes.byteSize + 8, true);
 				z = cv.getFloat64(inOffset + j * pointAttributes.byteSize + 16, true);
 
-				rtk_orientations[3 * j + 0] = x;
-				rtk_orientations[3 * j + 1] = y;
-				rtk_orientations[3 * j + 2] = z;
+				rtk_orients[3 * j + 0] = x;
+				rtk_orients[3 * j + 1] = y;
+				rtk_orients[3 * j + 2] = z;
 			}
 
 			attributeBuffers[pointAttribute.name] = { buffer: buff, attribute: pointAttribute };


### PR DESCRIPTION
This reverts commit fdbc39b0c35666cc288070f29ffb9ac785c8763c, reversing
changes made to bd478a32a1156be59615edf8ae97cad021295613.

Reverting the commit on develop that broke potree. The changes to RTK_POSE => RTK_POSITION etc. needs a more complete effort and is tabled for now.




