### PR TITLE
Fixes to animation

### DIFF
--- a/common/playbar.js
+++ b/common/playbar.js
@@ -60,8 +60,7 @@ export function createPlaybar () {
     // Add to DOM:
     $("#potree_render_area").append(playbarhtml);
 
-    // Define function to update clip range:
-    function updateClip(disable=false) {
+    function updateTimeWindow(disable=false) {
 
       const lidarOffset = window.animationEngine.tstart;
       const lidarRange = window.animationEngine.timeRange;
@@ -109,7 +108,7 @@ export function createPlaybar () {
                             const min = numberOrZero(tmin.value);
                             window.animationEngine.activeWindow.backward = min;
                             tmax.min = min;
-                            updateClip();
+                            updateTimeWindow();
                             window.animationEngine.updateTimeForAll();
                           });
 
@@ -118,25 +117,16 @@ export function createPlaybar () {
                             const max = numberOrZero(tmax.value);
                             window.animationEngine.activeWindow.forward = max;
                             tmin.max = max;
-                            updateClip();
+                            updateTimeWindow();
                             window.animationEngine.updateTimeForAll();
                           });
 
-    // Function to update slider:
-    function updateSlider(slideval=null) {
-
-      if (slideval) {
-        var slider = playbarhtml.find("#myRange");
-        slider.val(slideval);
-      }
-
-      updateClip();
-
+    function updateSlider(slideval) {
+      playbarhtml.find("#myRange").val(slideval);
+      updateTimeWindow();
     }
 
-    playbarhtml.find("#myRange").on('input', function() {
-      updateSlider();
-    });
+    playbarhtml.find("#myRange").on('input', updateTimeWindow);
 
     playbarhtml.find("#myRange").on('wheel', function(e) {
       var slider = playbarhtml.find("#myRange");
@@ -167,7 +157,7 @@ export function createPlaybar () {
     });
 
     playbarhtml.find("#playbar_toggle").click(function() {
-      updateClip(disable=this.checked);
+      updateTimeWindow(disable=this.checked);
     });
     playbarhtml.find("#playbar_toggle").trigger('click');
 

--- a/common/playbar.js
+++ b/common/playbar.js
@@ -81,7 +81,7 @@ export function createPlaybar () {
         const dtMin = window.animationEngine.activeWindow.backward;
         const dtMax = window.animationEngine.activeWindow.forward;
 
-        const tmin = t - dtMin;
+        const tmin = t + dtMin;
         const tmax = t + dtMax;
 
         window.viewer.setFilterGPSTimeRange(tmin, tmax);
@@ -90,6 +90,15 @@ export function createPlaybar () {
 
     const tmin = document.getElementById('playbar_tmin');
     const tmax = document.getElementById('playbar_tmax');
+
+    // Initialize DOM element values from initial activeWindow values
+    tmin.value = window.animationEngine.activeWindow.backward;
+    tmin.max = window.animationEngine.activeWindow.forward;
+    tmin.step = window.animationEngine.activeWindow.step;
+    tmax.value = window.animationEngine.activeWindow.forward;
+    tmax.min = window.animationEngine.activeWindow.backward;
+    tmax.step = window.animationEngine.activeWindow.step;
+
     tmin.addEventListener('input',
                           () => {
                             const min = Number(tmin.value);
@@ -124,18 +133,13 @@ export function createPlaybar () {
 
     playbarhtml.find("#myRange").on('wheel', function(e) {
       var slider = playbarhtml.find("#myRange");
-      // var tmin = playbarhtml.find("#playbar_tmin");
-      // var tmax = playbarhtml.find("#playbar_tmax");
       var slideval = Number(slider.val());
-      var dy = e.originalEvent.deltaY;
+      // var dy = e.originalEvent.deltaY;
 
       const tmin = window.animationEngine.activeWindow.backward;
       const tmax = window.animationEngine.activeWindow.forward;
 
-      var scalefactor = 1;
-      if (e.originalEvent.shiftKey) {
-        scalefactor = 100;
-      }
+      const scalefactor = e.originalEvent.shiftKey ? 100 : 1;
 
       var lidarRange = 1;
       try {
@@ -143,7 +147,7 @@ export function createPlaybar () {
         lidarRange = window.animationEngine.timeRange;
       } catch (e) {
       }
-      const dt = (dy < 0 ? tmax : -tmin) * scalefactor;
+      const dt = (tmax - tmin) * scalefactor;
       // dt = Number(tmax.val());
       //   dt = tmax;
       // } else if (dy > 0) {
@@ -262,7 +266,7 @@ export function createPlaybar () {
 
     window.addEventListener("message", e => {
      if (e.data === 'pause') {
-       animationEngine.stop()
+       window.animationEngine.stop()
      }
     });
 
@@ -431,18 +435,26 @@ function addPlaybarListeners() {
         animationEngine.updateTimeForAll();
     });
 
+    // Initialize DOM element values from initial elevationWindow values
+    zmin.value = window.animationEngine.elevationWindow.min;
+    zmin.max = window.animationEngine.elevationWindow.max;
+    zmin.step = window.animationEngine.elevationWindow.step;
+    zmax.value = window.animationEngine.elevationWindow.max;
+    zmax.min = window.animationEngine.elevationWindow.min;
+    zmax.step = window.animationEngine.elevationWindow.step;
+
     zmin.addEventListener("input", () => {
         const min = Number(zmin.value);
-        window.elevationWindow.min = min;
-        window.elevationWindow.max = Number(zmax.value);
+        window.animationEngine.elevationWindow.min = min;
+        window.animationEngine.elevationWindow.max = Number(zmax.value);
         zmax.min = min;
         animationEngine.updateTimeForAll();
     });
 
     zmax.addEventListener("input", () => {
         const max = Number(zmax.value);
-        window.elevationWindow.min = Number(zmin.value);
-        window.elevationWindow.max = max;
+        window.animationEngine.elevationWindow.min = Number(zmin.value);
+        window.animationEngine.elevationWindow.max = max;
         zmin.max = max;
         animationEngine.updateTimeForAll();
     });
@@ -450,9 +462,9 @@ function addPlaybarListeners() {
 	// PointCloud:
 	animationEngine.tweenTargets.push((gpsTime) => {
 		// debugger; // account for pointcloud offset
-		let minGpsTime = gpsTime-animationEngine.activeWindow.backward;
+		let minGpsTime = gpsTime+animationEngine.activeWindow.backward;
 		let maxGpsTime = gpsTime+animationEngine.activeWindow.forward;
 		viewer.setFilterGPSTimeRange(minGpsTime, maxGpsTime);
-		viewer.setFilterGPSTimeExtent(minGpsTime-1.5*animationEngine.activeWindow.backward, maxGpsTime+1.5*animationEngine.activeWindow.forward);
+		viewer.setFilterGPSTimeExtent(minGpsTime+1.5*animationEngine.activeWindow.backward, maxGpsTime+1.5*animationEngine.activeWindow.forward);
 	});
 }

--- a/demo/animationEngine.js
+++ b/demo/animationEngine.js
@@ -38,7 +38,7 @@ export class AnimationEngine {
     let durationMillis = this.timeRange*1000*this.playbackRate;
     this.tweenEngine = new TWEEN.Tween(this.timeline).to({t:this.tend}, durationMillis);
     this.tweenEngine.easing(TWEEN.Easing.Linear.None);
-    this.tweenEngine.onUpdate((t) => this.updateTimeForAll(t));
+    this.tweenEngine.onUpdate(() => this.updateTimeForAll(true));
     this.tweenEngine.onComplete(() => {
       if (this.repeat) {
         this.timeline.t = this.tstart;
@@ -71,11 +71,10 @@ export class AnimationEngine {
     this.tweenEngine.update(t);
   }
 
-  updateTimeForAll(t) {
-
+  updateTimeForAll(updateDisplayedTime) {
     // Update all targets with current time
     for(let ii=0, len=this.tweenTargets.length; ii<len; ii++) {
-      this.tweenTargets[ii](this.timeline.t);
+      this.tweenTargets[ii](this.timeline.t, updateDisplayedTime);
     }
   }
 }

--- a/demo/animationEngine.js
+++ b/demo/animationEngine.js
@@ -1,15 +1,17 @@
+'use strict';
 
-"use strict"
 export class AnimationEngine {
 
-  constructor() {
+  constructor(initialValues) {
 
     // TODO Use TWEEN.Group()....doesn't work though...why? It's in the documentation
     // this.tweenGroup = TWEEN.Group(); // Tween Group containing all animated objects
     this.tstart = undefined;  // Starting time for animation (reference time, aka GPS Time)
     this.tend = undefined;  // Ending time for animation (reference time, aka GPS Time)
     this.timeline = undefined;
-    this.activeWindow = {forward: 0.05, backward: 0.05}; // Defines the size of the window around the current time step
+    // Make copies of initial values, so they can be modified
+    this.activeWindow = {...initialValues.activeWindow}; // Defines the size of the window around around the current time step
+    this.elevationWindow = {...initialValues.elevationWindow};
     this.timeRange = undefined;
     this.preStartCallback = undefined; // Callback run before start() executes
     this.preStopCallback = undefined; // Callback run before stop() executes

--- a/demo/loaderHelper.js
+++ b/demo/loaderHelper.js
@@ -29,11 +29,16 @@ $(document).ready(() => {
 export function loadPotree() {
 	$(document).ready(() => {
 		// Create AnimationEngine:
-		createViewer();
-		window.animationEngine = new AnimationEngine();
+	        const viewer = createViewer();
+                window.viewer = viewer;
+                const animationEngine = new AnimationEngine({
+                  activeWindow: {backward: -0.05, forward: 0.05, step: "0.01"},
+                  elevationWindow: {min: -0.05, max: 0.05, step: "0.01"}
+                });
+		window.animationEngine = animationEngine;
 
 		// add html element with listeners to document
-		createPlaybar();
+	        createPlaybar();
 
 		addReloadLanesButton();
 		addLoadGapsButton();
@@ -48,8 +53,8 @@ export function loadPotree() {
 
 // loads all necessary data (car obj/texture, rtk, radar, tracks, etc...)
 function loadDataIntoDocument() {
-	// Load Data Sources in loadRtkCallback:
-	loadRtkCallback(s3, bucket, name, () => {
+	        // Load Data Sources in loadRtkCallback:
+                loadRtkCallback(s3, bucket, name, () => {
 
 		// Load Extrinsics:
 		window.extrinsics = { rtk2Vehicle: null, velo2Rtk: {} };

--- a/demo/rtkLoader.js
+++ b/demo/rtkLoader.js
@@ -192,7 +192,6 @@ export function applyRotation(obj, roll, pitch, yaw) {
 export function animateRTK() {
 	window.updateCamera = true;
 	window.pitchThreshold = 1.00;
-	window.elevationWindow = { min: 1, max: 1, z: 0 };
 	animationEngine.tweenTargets.push((gpsTime) => {
 		try {
 			let t = (gpsTime - animationEngine.tstart) / (animationEngine.timeRange);
@@ -233,11 +232,12 @@ export function animateRTK() {
 			// let elevationDeltaMin = -0;
 			// let elevationDeltaMax = 2;
 			let clouds = viewer.scene.pointclouds;
+                        const elevationWindow = window.animationEngine.elevationWindow;
 			for (let ii = 0, numClouds = clouds.length; ii < numClouds; ii++) {
                                 meshPosition.setFromMatrixPosition(mesh.matrixWorld);
                                 const zheight = meshPosition.z;
-			        window.elevationWindow.z = zheight;
-				viewer.scene.pointclouds[ii].material.elevationRange = [window.elevationWindow.z + window.elevationWindow.min, window.elevationWindow.z + window.elevationWindow.max];
+			        elevationWindow.z = zheight;
+				viewer.scene.pointclouds[ii].material.elevationRange = [elevationWindow.z + elevationWindow.min, elevationWindow.z + elevationWindow.max];
 				// TODO set elevation slider range extent
 			}
 

--- a/demo/textureLoader.js
+++ b/demo/textureLoader.js
@@ -1,4 +1,5 @@
-"use strict"
+'use strict';
+
 import { applyRotation } from "../demo/rtkLoader.js";
 import { removeLoadingScreen } from "../common/overlay.js";
 
@@ -56,7 +57,7 @@ function onLoadVehicleCallback(object, rtkTrajectory, texture, pos, rot) {
     const vehicleGroup = new THREE.Group();
     vehicleGroup.name = "Vehicle";
 
-    // render the path 
+    // render the path
     let geometry = new THREE.Geometry();
     for (let ii = 0; ii < rtkTrajectory.numStates; ii++) {
         geometry.vertices[ii] = rtkTrajectory.states[ii].pose.clone();
@@ -95,7 +96,7 @@ function onLoadVehicleCallback(object, rtkTrajectory, texture, pos, rot) {
     // axesHelper.rotateOnAxis(new THREE.Vector3(0,0,1), -Math.PI/2);
     axesHelper.visible = false;
     viewer.scene.dispatchEvent({ "type": "vehicle_layer_added", "vehicleLayer": axesHelper });
-    
+
     // Add Polar Grid Helper
     vehicleGroup.add(gridHelper);
     vehicleGroup.add(polarGridHelper);
@@ -126,5 +127,13 @@ function onLoadVehicleCallback(object, rtkTrajectory, texture, pos, rot) {
     viewer.scene.dispatchEvent({ "type": "vehicle_layer_added", "vehicleLayer": object });
 
     viewer.setFilterGPSTimeRange(0, 0); // Size 0 Time Window at start of timeline
+
+    // This is to force the initial complete render
+    // The fact that it is here is a complete kludge. I just kept looking for
+    // places to put it, until I found one that worked.
+    // None of the more obvious, more principled places worked, and I decided
+    // I had more important things to do.
+    window.animationEngine.updateTimeForAll();
+
     removeLoadingScreen();
 }

--- a/demo/viewer.js
+++ b/demo/viewer.js
@@ -5,7 +5,7 @@ import { visualizationMode, annotateLanesAvailable, downloadLanesAvailable,
 import { updateSidebar, togglePointClass } from "../common/custom-sidebar.js"
 
 export function createViewer() {
-	window.viewer = new Potree.Viewer(document.getElementById("potree_render_area"));
+	const viewer = new Potree.Viewer(document.getElementById("potree_render_area"));
 	viewer.setEDLEnabled(true);
 	viewer.setFOV(60);
 	viewer.setPointBudget(1 * 1000 * 1000);
@@ -59,4 +59,5 @@ export function createViewer() {
 			}
 		}
 	});
+        return viewer;
 }

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -581,8 +581,8 @@ export class Viewer extends EventDispatcher{
 	}
 
 	setFilterGPSTimeRange(from, to){
-		this.filterGPSTimeRange = [from, to];
-		this.dispatchEvent({'type': 'filter_gps_time_range_changed', 'viewer': this});
+	        this.filterGPSTimeRange = [from, to];
+	        this.dispatchEvent({'type': 'filter_gps_time_range_changed', 'viewer': this});
 	}
 
 	setFilterGPSTimeExtent(from, to){


### PR DESCRIPTION
My changes for making mins and maxes more flexible and organized,
missed a couple of places. Fix those.

Put elevationWindow into animationEngine, as activeWindow is. This
fixes some inconsistencies.

Put initial values for activeWindow and elevationWindow as an argument
to the AnimationEngine constructor. Take those values, and shove them
in the playbar DOM, overriding anything in the HTML. [I'm afraid to
take them out of the HTML, but maybe someday....]

Baby steps at cleaning up the spaghetti mess of potree code.
