### PR TITLE
Reenable using potree locally, with local files

### DIFF
--- a/common/overlay.js
+++ b/common/overlay.js
@@ -4,7 +4,7 @@ $(document).ready(function () {
   // get correct fonts/themes
   const params = new URLSearchParams(location.search);
   const theme = JSON.parse(params.get("theme")) // material-ui theme 
-  const loadingBarColor = theme.palette.secondary.main;
+  const loadingBarColor = theme ? theme.palette.secondary.main : "#edac3e";
 
   // Insert HTML for Playbar/Loading Bars:
   // data-stroke-width & data-stroke-width determines the height of the bar

--- a/demo/calibrationManager.js
+++ b/demo/calibrationManager.js
@@ -1,7 +1,4 @@
-"use strict"
-import { runForLocalDevelopment, s3, bucket, name } from "../demo/paramLoader.js"
-import { PointAttributeNames } from "../src/loader/PointAttributes.js";
-import { togglePointClass } from "../common/custom-sidebar.js"
+'use strict';
 
 export async function storeCalibration(s3, bucket, name, callback) {
   // TODO
@@ -144,68 +141,4 @@ export function addCalibrationButton() {
 	});
 
 	window.canEnableCalibrationPanels = true;
-	function canUseCalibrationPanels(attributes) {
-		let hasRtkPose = false;
-		let hasRtkOrient = false;
-		for (let attr of attributes) {
-			hasRtkPose = hasRtkPose || (attr.name === PointAttributeNames.RTK_POSE);
-			hasRtkOrient = hasRtkOrient || (attr.name === PointAttributeNames.RTK_ORIENT);
-		}
-		return hasRtkPose && hasRtkOrient
-	}
-
-	// Load Pointclouds
-	if (runForLocalDevelopment) {
-		Potree.loadPointCloud("../pointclouds/test/cloud.js", "full-cloud", e => {
-			const pointcloud = e.pointcloud;
-			const material = pointcloud.material;
-			viewer.scene.addPointCloud(pointcloud);
-			material.pointColorType = Potree.PointColorType.INTENSITY; // any Potree.PointColorType.XXXX
-			material.gradient = Potree.Gradients.GRAYSCALE; // Can define custom gradient or look up in Potree.Gradients
-			material.size = 0.09;
-			material.pointSizeType = Potree.PointSizeType.ADAPTIVE;
-			material.shape = Potree.PointShape.SQUARE;
-
-			let cloudCanUseCalibrationPanels = canUseCalibrationPanels(pointcloud.pcoGeometry.pointAttributes.attributes);
-			window.canEnableCalibrationPanels = window.canEnableCalibrationPanels && cloudCanUseCalibrationPanels;
-
-			if (window.canEnableCalibrationPanels) {
-				$(document).ready(() => enablePanels());
-
-			} else {
-				$(document).ready(() => {
-					let reason = "Pointcloud was not serialized with the necessary point attributes"
-					disablePanels(reason);
-					console.error("Cannot use calibration panels: ", reason);
-				});
-			}
-		});
-
-	} else {
-		Potree.loadPointCloud({ s3, bucket, name }, name.substring(5), e => {
-			const pointcloud = e.pointcloud;
-			const material = pointcloud.material;
-			viewer.scene.addPointCloud(pointcloud);
-			material.pointColorType = Potree.PointColorType.INTENSITY; // any Potree.PointColorType.XXXX
-			material.gradient = Potree.Gradients.GRAYSCALE;
-			material.size = 0.09;
-			material.pointSizeType = Potree.PointSizeType.ADAPTIVE;
-			material.shape = Potree.PointShape.SQUARE;
-
-			let cloudCanUseCalibrationPanels = canUseCalibrationPanels(pointcloud.pcoGeometry.pointAttributes.attributes);
-			window.canEnableCalibrationPanels = window.canEnableCalibrationPanels && cloudCanUseCalibrationPanels;
-
-			if (window.canEnableCalibrationPanels) {
-				$(document).ready(() => enablePanels());
-
-			} else {
-				$(document).ready(() => {
-					disablePanels("Pointcloud was not serialized with the necessary point attributes");
-					console.error("Cannot use calibration panels");
-				});
-			}
-
-			$("#playbutton").click();
-		});
-	}
 }

--- a/demo/paramLoader.js
+++ b/demo/paramLoader.js
@@ -1,5 +1,6 @@
+'use strict';
+
 // This file contains common constant variables (some of which are pulled from the url params)
-"use strict"
 export const runForLocalDevelopment = location.search === "" && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
 export const params = new URLSearchParams(location.search);
 export const bucket = params.get("bucket");


### PR DESCRIPTION
If there is no theme, use a default color for loading bar.
That is the one-line change in overlay.js.

While trying to figure out what was going on, I remodularized some code, putting
some things where they "belong". There is no functional change with these changes,
they are purely cosmetic.

- The code for actually loading the point clouds should not be part of
  calibrationManager.js. Move it from there to loaderHelper.js.
- Within loaderHelper, LoadPotree() is called when the document is ready.
  So actions within it do not need to wait further.
- I made the finishedLoading function, extracting the common code from the
  two callbacks for Potree.loadPointCloud().


Please follow these instructions when creating a new pull request:

* Set the potree develop branch as the PR target.
* Builds should not be part of the PR. Don't commit them. 
* Do not use a formatter. They make a mess out of diffs. 
* It takes a lot of time to download and test, as well as analyze the diffs,
so please excuse if it takes time to respond or if you don't get a response. 





