### PR TITLE
More playbar cleanup

### DIFF
--- a/common/playbar.css
+++ b/common/playbar.css
@@ -78,7 +78,6 @@
   top: 0px;
   /* padding-top: 10px; */
   /* padding-bottom: 5px; */
-  font-family: 'Open Sans', sans-serif;
   font-size: 125%
 }
 
@@ -135,12 +134,12 @@ input::-webkit-inner-spin-button {
   background: none;
   border: none;
   color: white;
-  font-family: 'Open Sans', sans-serif;
   font-size: 100%;
 }
 
 #time_display {
-  width: 125px;
+    width: 100px;
+    text-align: right;
 }
 
 #windows {

--- a/common/playbar.js
+++ b/common/playbar.js
@@ -29,12 +29,12 @@ export function createPlaybar () {
             <table id="windows">
               <tr>
                 <td style="text-align:right">Time Window:</td>
-                <td>[<input type="number" id="playbar_tmin" value=-0.05 max=0.05 step="0.01">, <input type="number" id="playbar_tmax" value=0.05 min=-0.05 step="0.01">]</td>
+                <td>[<input type="number" id="playbar_tmin">, <input type="number" id="playbar_tmax">]</td>
                 <td>(s)</td>
               </tr>
               <tr>
                 <td style="text-align:right">Elevation Window:</td>
-                <td>[<input type="number" id="elevation_min" value=-0.5 max=0.5 step="0.01">, <input type="number" id="elevation_max" value=0.5 min=-0.5 step="0.01">]</td>
+                <td>[<input type="number" id="elevation_min">, <input type="number" id="elevation_max">]</td>
                 <td>(m)</td>
               </tr>
             </table>
@@ -79,16 +79,9 @@ export function createPlaybar () {
         const t = sliderVal * lidarRange + lidarOffset;
         $("#demo").html((t-lidarOffset).toFixed(4));
 
-        // var dtMin = Number($("#playbar_tmin").val());
-        // var dtMax = Number($("#playbar_tmax").val());
-
-        const dtMin = window.animationEngine.activeWindow.backward;
-        const dtMax = window.animationEngine.activeWindow.forward;
-
-        const tmin = t + dtMin;
-        const tmax = t + dtMax;
-
-        window.viewer.setFilterGPSTimeRange(tmin, tmax);
+        const dtMin = numberOrZero(window.animationEngine.activeWindow.backward);
+        const dtMax = numberOrZero(window.animationEngine.activeWindow.forward);
+        window.viewer.setFilterGPSTimeRange(t + dtMin, t + dtMax);
       }
     }
 
@@ -126,7 +119,8 @@ export function createPlaybar () {
       updateTimeWindow();
     }
 
-    playbarhtml.find("#myRange").on('input', updateTimeWindow);
+    // Make sure to call updateTimeWindow with disable false
+    playbarhtml.find("#myRange").on('input', () => updateTimeWindow());
 
     playbarhtml.find("#myRange").on('wheel', function(e) {
       const slider = playbarhtml.find("#myRange");
@@ -450,8 +444,8 @@ function addPlaybarListeners() {
 	// PointCloud:
 	animationEngine.tweenTargets.push((gpsTime) => {
 		// debugger; // account for pointcloud offset
-		let minGpsTime = gpsTime+animationEngine.activeWindow.backward;
-		let maxGpsTime = gpsTime+animationEngine.activeWindow.forward;
+                const minGpsTime = gpsTime+numberOrZero(animationEngine.activeWindow.backward);
+                const maxGpsTime = gpsTime+numberOrZero(animationEngine.activeWindow.forward);
 		viewer.setFilterGPSTimeRange(minGpsTime, maxGpsTime);
 		viewer.setFilterGPSTimeExtent(minGpsTime+1.5*animationEngine.activeWindow.backward, maxGpsTime+1.5*animationEngine.activeWindow.forward);
 	});

--- a/common/playbar.js
+++ b/common/playbar.js
@@ -22,20 +22,20 @@ export function createPlaybar () {
                 <td><input type="checkbox" id="toggleplay">
                 <button class="button" class="play" id="playbutton" class="inline"><i class="material-icons">play_arrow</i></button>
                 <button class="button" class="pause" id="pausebutton"><i class="material-icons">pause</i></button></td>
-                <td>Time (s): <input type="number" id="time_display" min=0 value=0 step="0.001"></td>
+                <td><input type="number" id="time_display" min=0 value=0 step="0.001"> s</td>
               </tr>
             </table>
 
             <table id="windows">
               <tr>
-                <td style="text-align:right">Time Window:</td>
+                <td style="text-align:right">Time Window</td>
                 <td>[<input type="number" id="playbar_tmin">, <input type="number" id="playbar_tmax">]</td>
-                <td>(s)</td>
+                <td style="text-align:left">s</td>
               </tr>
               <tr>
-                <td style="text-align:right">Elevation Window:</td>
+                <td style="text-align:right">Elevation Window</td>
                 <td>[<input type="number" id="elevation_min">, <input type="number" id="elevation_max">]</td>
-                <td>(m)</td>
+                <td style="text-align:left">m</td>
               </tr>
             </table>
 

--- a/common/playbar.js
+++ b/common/playbar.js
@@ -444,9 +444,10 @@ function addPlaybarListeners() {
 	// PointCloud:
 	animationEngine.tweenTargets.push((gpsTime) => {
 		// debugger; // account for pointcloud offset
-                const minGpsTime = gpsTime+numberOrZero(animationEngine.activeWindow.backward);
-                const maxGpsTime = gpsTime+numberOrZero(animationEngine.activeWindow.forward);
-		viewer.setFilterGPSTimeRange(minGpsTime, maxGpsTime);
-		viewer.setFilterGPSTimeExtent(minGpsTime+1.5*animationEngine.activeWindow.backward, maxGpsTime+1.5*animationEngine.activeWindow.forward);
+                const {backward, forward} = animationEngine.activeWindow;
+                const timeMin = numberOrZero(backward);
+                const timeMax = numberOrZero(forward);
+		viewer.setFilterGPSTimeRange(gpsTime + timeMin, gpsTime + timeMax);
+		viewer.setFilterGPSTimeExtent(gpsTime + 2.5 * timeMin, gpsTime + 2.5 * timeMax);
 	});
 }

--- a/demo/loaderHelper.js
+++ b/demo/loaderHelper.js
@@ -65,8 +65,8 @@ export function loadPotree() {
   const viewer = createViewer();
   window.viewer = viewer;
   const animationEngine = new AnimationEngine({
-    activeWindow: {backward: -0.05, forward: 0.05, step: "0.01"},
-    elevationWindow: {min: -0.05, max: 0.05, step: "0.01"}
+    activeWindow: {backward: '-0.05', forward: '0.05', step: '0.01'},
+    elevationWindow: {min: '-1.00', max: '2.00', step: '0.01'}
   });
   window.animationEngine = animationEngine;
 

--- a/demo/rtkLoader.js
+++ b/demo/rtkLoader.js
@@ -233,11 +233,15 @@ export function animateRTK() {
 			// let elevationDeltaMax = 2;
 			let clouds = viewer.scene.pointclouds;
                         const elevationWindow = window.animationEngine.elevationWindow;
+                        const {min, max} = elevationWindow;
+                        const elevationMin = Number(min);
+                        const elevationMax = Number(max);
 			for (let ii = 0, numClouds = clouds.length; ii < numClouds; ii++) {
                                 meshPosition.setFromMatrixPosition(mesh.matrixWorld);
                                 const zheight = meshPosition.z;
+                                // Is this setting ever used?
 			        elevationWindow.z = zheight;
-				viewer.scene.pointclouds[ii].material.elevationRange = [elevationWindow.z + elevationWindow.min, elevationWindow.z + elevationWindow.max];
+			        viewer.scene.pointclouds[ii].material.elevationRange = [zheight + elevationMin, zheight + elevationMax];
 				// TODO set elevation slider range extent
 			}
 

--- a/src/viewer/PropertyPanels/PropertiesPanel.js
+++ b/src/viewer/PropertyPanels/PropertiesPanel.js
@@ -535,8 +535,7 @@ export class PropertiesPanel{
 				let bMax = box.max.z + 0.2 * bWidth;
 
 				let range = material.elevationRange;
-
-				panel.find('#lblHeightRange').html(`${range[0].toFixed(2)} to ${range[1].toFixed(2)}`);
+				panel.find('#lblHeightRange').html(`${Number(range[0]).toFixed(2)} to ${Number(range[1]).toFixed(2)}`);
 				panel.find('#sldHeightRange').slider({min: bMin, max: bMax, values: range});
 			};
 


### PR DESCRIPTION
Set initial elevation range to [-1.00, 2.00]; use strings to force trailing zeros.
Convert min and max values to numbers, before using them.
Remove initial input values from HTML, since they are now set by code.
Fix a bug where range was being disabled.
