### PR TITLE
Merge fix/load-local-tracks into develop

### DIFF
--- a/demo/trackLoader.js
+++ b/demo/trackLoader.js
@@ -83,7 +83,13 @@ export async function loadTracks(s3, bucket, name, shaderMaterial, animationEngi
       }
 
       let bytesArray = new Uint8Array(response);
-      const trackGeometries = parseTracks(bytesArray, shaderMaterial, FlatbufferModule, animationEngine);
+      const trackGeometries = await parseTracks(bytesArray, shaderMaterial, FlatbufferModule, animationEngine);
+      loadingBarTotal.set(Math.min(Math.ceil(loadingBarTotal.value + (100/numberTasks))), 100);
+      loadingBar.set(0);
+      if (loadingBarTotal.value >= 100) {
+        removeLoadingScreen();
+      }
+      await pause();
       await callback(trackGeometries, );
     };
 


### PR DESCRIPTION
Hey Bob, this problem is referring to not being able to load local tracks when visualizing a local pointcloud using potree. This is not a visualizing problem which is a different issue, which we have a temporary fix for. 

Essentially, I needed the `await` keyword before `parseTracks`. I also added a few lines to match what you have for the tracks in S3. You probably know if what I have matches with what you've changed lately.
