### PR TITLE
[fix] REM points not showing

### DIFF
--- a/demo/animationEngine.js
+++ b/demo/animationEngine.js
@@ -9,9 +9,11 @@ export class AnimationEngine {
     this.tstart = undefined;  // Starting time for animation (reference time, aka GPS Time)
     this.tend = undefined;  // Ending time for animation (reference time, aka GPS Time)
     this.timeline = undefined;
+
     // Make copies of initial values, so they can be modified
-    this.activeWindow = {...initialValues.activeWindow}; // Defines the size of the window around around the current time step
-    this.elevationWindow = {...initialValues.elevationWindow};
+    // Defines the size of the window around around the current time step
+    this.activeWindow = this.initValues(initialValues.activeWindow)
+    this.elevationWindow = this.initValues(initialValues.elevationWindow)
     this.timeRange = undefined;
     this.preStartCallback = undefined; // Callback run before start() executes
     this.preStopCallback = undefined; // Callback run before stop() executes
@@ -20,6 +22,15 @@ export class AnimationEngine {
     this.tweenEngine = undefined; // Linear Tween between tstart and tend that controls all other tweens
     this.tweenTargets = []; // List of custom update functions for all targets - called by tweenEngine
     this.isPlaying = false;
+  }
+
+  initValues(dict) {
+    const toRtn = {} 
+    for (const [key, val] of Object.entries(dict)) {
+      // causes issues if not a Number
+      toRtn[key] = Number(val)
+    }
+    return toRtn
   }
 
   configure(tstart, tend, playbackRate, tweenTargets, repeat) {

--- a/demo/loaderHelper.js
+++ b/demo/loaderHelper.js
@@ -4,7 +4,8 @@
 import {
 	runForLocalDevelopment, params, bucket, region, names, name, visualizationMode,
 	annotateLanesAvailable, downloadLanesAvailable, calibrationModeAvailable, accessKeyId,
-	secretAccessKey, sessionToken, fonts, theme, comparisonDatasets, s3, getShaderMaterial
+	secretAccessKey, sessionToken, fonts, theme, comparisonDatasets, s3, getShaderMaterial,
+	defaultTimeRange
 } from "../demo/paramLoader.js"
 import { createViewer } from "../demo/viewer.js"
 import { AnimationEngine } from "../demo/animationEngine.js"
@@ -65,7 +66,7 @@ export function loadPotree() {
   const viewer = createViewer();
   window.viewer = viewer;
   const animationEngine = new AnimationEngine({
-    activeWindow: {backward: -0.05, forward: 0.05, step: 0.01},
+    activeWindow: {backward: defaultTimeRange.min, forward: defaultTimeRange.max, step: 0.01},
     elevationWindow: {min: -1.00, max: 2.00, step: 0.01}
   });
   window.animationEngine = animationEngine;

--- a/demo/loaderHelper.js
+++ b/demo/loaderHelper.js
@@ -65,8 +65,8 @@ export function loadPotree() {
   const viewer = createViewer();
   window.viewer = viewer;
   const animationEngine = new AnimationEngine({
-    activeWindow: {backward: '-0.05', forward: '0.05', step: '0.01'},
-    elevationWindow: {min: '-1.00', max: '2.00', step: '0.01'}
+    activeWindow: {backward: -0.05, forward: 0.05, step: 0.01},
+    elevationWindow: {min: -1.00, max: 2.00, step: 0.01}
   });
   window.animationEngine = animationEngine;
 

--- a/demo/paramLoader.js
+++ b/demo/paramLoader.js
@@ -60,14 +60,19 @@ if (!(s3 || window.location.hostname === 'localhost' || window.location.hostname
 // const stream = s3.getObject({Bucket: bucket,
 //                              Key: name}).createReadStream();
 
+export const defaultTimeRange = {
+    min: -0.05,
+    max:  0.05,
+    initial: 0
+}
 
 // returns a THREE.ShaderMaterial object that should be used as standard 
 export function getShaderMaterial() {
     let uniforms = {
         color: { value: new THREE.Color(0x00ff00) },
-        minGpsTime: { value: 0.0 },
-        maxGpsTime: { value: 0.5 },
-        initialTime: { value: 0 }, // TODO not used
+        minGpsTime: { value: defaultTimeRange.min },
+        maxGpsTime: { value: defaultTimeRange.max },
+        initialTime: { value: defaultTimeRange.initial }, // TODO not used
         // offset: {value: new THREE.Vector3(0,0,0)}
     };
     let shaderMaterial = new THREE.ShaderMaterial({

--- a/demo/remLoader.js
+++ b/demo/remLoader.js
@@ -132,7 +132,7 @@ async function createControlMeshes(controlPoints, remShaderMaterial, FlatbufferM
     .value() - animationEngine.tstart;
     
     
-    const timestampArray = Array(64).fill(timestamp)
+    const timestampArray = new Float64Array(64).fill(timestamp)
 
     const sphereGeo = new THREE.SphereBufferGeometry(radius);
     remShaderMaterial.uniforms.color.value = new THREE.Color(0x00ffff);
@@ -161,7 +161,7 @@ export async function loadRemCallback(s3, bucket, name, animationEngine) {
 	await loadRem(s3, bucket, name, remShaderMaterial, animationEngine, (sphereMeshes) => {
 		const remLayer = new THREE.Group();
     remLayer.name = "REM Control Points";
-    sphereMeshes.map(mesh => remLayer.add(mesh))
+    sphereMeshes.forEach(mesh => remLayer.add(mesh))
 
 		viewer.scene.scene.add(remLayer);
 		const e = new CustomEvent("truth_layer_added", {detail: remLayer, writable: true});

--- a/demo/rtkLoader.js
+++ b/demo/rtkLoader.js
@@ -249,7 +249,7 @@ export function animateRTK() {
 			for (let ii = 0, numClouds = clouds.length; ii < numClouds; ii++) {
 				let material = clouds[ii].material;
 				material.uniforms.currentRtkPosition.value = state.pose.clone();
-				material.uniforms.currentRtkOrientation.value = state.orient.toVector3().clone();
+				material.uniforms.currentRtkOrientation.value = state.orient.clone();
 			}
 		} catch (e) {
 			console.error("Caught error: ", e);


### PR DESCRIPTION
- closes #146 -- contains some screenshots
- couple of issues:
    - biggest one- starting time window contained strings instead of Numbers. 
        - The code would convert tend & tstart to numbers when the time window was changed which explains why that phenomenon existed
            - animationEngine.js now explicitly converts inputs to Numbers to ensure this does not occur again 
        - see #149 `tracks don't appear after selected until time window is adjusted (need to refresh it or change both sides of the time-window)`
    - error in getting rtk orient which did not let needed values get set
    - updated remLoader.js to predominantly use `const` instead of `let` (helped diagnose issue)
    - lastly, started with >10 points instead of 2-4 points that show when `start` or time window is adjusted
        - due to initial gps time window (which was different from initial time window) being .5s instead of .05 
        - they have been tied to a single point of truth within paramLoader.js