### PR TITLE
[fix] annotations object jstree will not be open on load

### DIFF
--- a/src/viewer/sidebar.js
+++ b/src/viewer/sidebar.js
@@ -331,11 +331,6 @@ export class Sidebar{
 		tree.on('create_node.jstree', (e, data) => {
 			tree.jstree("open_all");
 			tree.jstree().close_node(annotationsID);
-
-			// tree.jstree().open_node(pcID)
-			// tree.jstree().open_node(measurementID)
-			// tree.jstree().open_node(otherID)
-
 		});
 
 		tree.on("select_node.jstree", (e, data) => {

--- a/src/viewer/sidebar.js
+++ b/src/viewer/sidebar.js
@@ -330,6 +330,12 @@ export class Sidebar{
 
 		tree.on('create_node.jstree', (e, data) => {
 			tree.jstree("open_all");
+			tree.jstree().close_node(annotationsID);
+
+			// tree.jstree().open_node(pcID)
+			// tree.jstree().open_node(measurementID)
+			// tree.jstree().open_node(otherID)
+
 		});
 
 		tree.on("select_node.jstree", (e, data) => {


### PR DESCRIPTION
This PR prevents anomalies from being displayed in the sidebar on load. The user can show to open the Annotations object and view anomalies there. 





