### PR TITLE
Remodularize the way that files are checked for loading.

### DIFF
--- a/demo/calibrationManager.js
+++ b/demo/calibrationManager.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { updateLoadingBar, incrementLoadingBarTotal } from "../common/overlay.js";
-import { existsOrNull } from "./loaderHelper.js"
+import { getFileInfo } from "./loaderUtilities.js";
 
 export async function storeCalibration(s3, bucket, name, callback) {
   // TODO
@@ -18,19 +18,18 @@ export async function loadRtk2Vehicle(s3, bucket, name, callback) {
   callback(rtk2Vehicle);
 }
 
-const calFiles = {objectName: null}
+let calFiles = null;
 export const calDownloads = async (datasetFiles) => {
   // ${name}/7_cals/extrinsics.txt
-  const localCal = `../cals/extrinsics.txt`
-  const isLocalLoad = datasetFiles == null
-  calFiles.objectName = isLocalLoad ?
-    await existsOrNull(localCal) : datasetFiles.filter(path => path.endsWith("extrinsics.txt"))[0]
-  return calFiles
+  calFiles = await getFileInfo(datasetFiles,
+                               "extrinsics.txt",
+                               "../cals/extrinsics.txt");
+  return calFiles;
 }
 
 export async function loadVelo2Rtk(s3, bucket, name, callback) {
   const tstart = performance.now();
-  if (calFiles.objectName == null) {
+  if (!calFiles) {
     console.log("No calibration files present")
     return
   }

--- a/demo/loaderHelper.js
+++ b/demo/loaderHelper.js
@@ -268,35 +268,16 @@ async function determineNumTasks(datasetFiles) {
 	let numDownloads = 0 // generally incremented by if objectName is present in the returned dictionary
 	let numLoads = 0 // normally incremented with numDownloads except when texture/mesh is present (increment solely)
 	for (const getRelevantFiles of downloadList) {
-		const relevantFiles = await getRelevantFiles(datasetFiles)
-		if (relevantFiles.objectName != null) {
-			numDownloads++
-			numLoads++
-		}
-		// special case for textureLoader (loads 2 things, but only one is trackable, so combine)
-		else if (relevantFiles.texture && relevantFiles.mesh) {
-			numLoads++
-		}
+	  const relevantFiles = await getRelevantFiles(datasetFiles)
+	  if (relevantFiles) {
+            if (relevantFiles.texture && relevantFiles.mesh) {
+	      // special case for textureLoader (loads 2 things, but only one is trackable, so combine)
+              numLoads++;
+            } else {
+	      numDownloads++;
+	      numLoads++;
+	    }
+          }
 	}
-	return numLoads + numDownloads
-}
-
-/**
- * @brief Helper function for loaders to determine if a local point cloud file exists
- * @param {String} path
- * @returns {String | null} Returns 'path' if exists, null if file does not exist
- */
-export async function existsOrNull(path) {
-    return new Promise((resolve, reject) => {
-        const req = new XMLHttpRequest();
-        req.open('HEAD', path, true)
-        req.onreadystatechange = () => {
-            if (req.readyState === 4) { // completed (error or done)
-                const fileExists = req.status == 200
-                const toRtn = fileExists ? path : null
-                resolve(toRtn)
-            }
-        }
-        req.send()
-    })
+  return numLoads + numDownloads;
 }

--- a/demo/loaderUtilities.js
+++ b/demo/loaderUtilities.js
@@ -1,0 +1,46 @@
+'use strict';
+
+
+/**
+ * @brief Helper function for loaders to determine if a local point cloud file exists
+ * @param {String} path
+ * @returns {String | null} Returns 'path' if exists, null if file does not exist
+ */
+async function existsOrNull(path) {
+    return new Promise((resolve, reject) => {
+        const req = new XMLHttpRequest();
+        req.open('HEAD', path, true)
+        req.onreadystatechange = () => {
+            if (req.readyState === 4) { // completed (error or done)
+                const fileExists = req.status == 200
+                const toRtn = fileExists ? path : null
+                resolve(toRtn)
+            }
+        }
+        req.send()
+    })
+}
+
+export const getFbFileInfo = async (datasetFiles, objNameMatch, schemaMatch, localObj, localSchema) =>
+  {
+    if (datasetFiles) {
+      const objectName = datasetFiles.filter(path => path.endsWith(objNameMatch))[0];
+      const schemaFile = datasetFiles.filter(path => path.endsWith(schemaMatch))[0];
+      return objectName && schemaFile && {objectName, schemaFile};
+    } else {
+      const objectName = await existsOrNull(localObj);
+      const schemaFile = await existsOrNull(localSchema);
+      return objectName && schemaFile && {objectName, schemaFile};
+    }
+  };
+
+export const getFileInfo = async (datasetFiles, objNameMatch, localObj) =>
+  {
+    if (datasetFiles) {
+      const objectName = datasetFiles.filter(path => path.endsWith(objNameMatch))[0];
+      return objectName && {objectName};
+    } else {
+      const objectName = await existsOrNull(localObj);
+      return objectName && {objectName};
+    }
+  };

--- a/demo/remLoader.js
+++ b/demo/remLoader.js
@@ -1,28 +1,23 @@
 'use strict';
 import { getShaderMaterial } from "../demo/paramLoader.js"
 import { updateLoadingBar, incrementLoadingBarTotal } from "../common/overlay.js";
-import { existsOrNull } from "./loaderHelper.js"
+import { getFbFileInfo } from "./loaderUtilities.js";
 
 
-
+let remFiles = null;
 // sets local variable and returns so # files can be counted
-const remFiles = {objectName: null, schemaFile: null}
 export const remDownloads = async (datasetFiles) => {
-  const isLocalLoad = datasetFiles == null
-  const localObj = `../data/control_point_3_rtk_relative.fb`;
-  const localSchema = "../schemas/VisualizationPrimitives_generated.js";
-  const objNameMatch = "control_point_3_rtk_relative.fb" // 3_Assessments
-  const schemaMatch = "VisualizationPrimitives_generated.js" // 5_Schemas
-  remFiles.objectName = isLocalLoad ?
-    await existsOrNull(localObj) : datasetFiles.filter(path => path.endsWith(objNameMatch))[0]
-  remFiles.schemaFile = isLocalLoad ?
-    await existsOrNull(localSchema) : datasetFiles.filter(path => path.endsWith(schemaMatch))[0]
-  return remFiles
+  remFiles = await getFbFileInfo(datasetFiles,
+                                 "control_point_3_rtk_relative.fb", // 3_Assessments
+                                 "VisualizationPrimitives_generated.js", // 5_Schemas
+                                 "../data/control_point_3_rtk_relative.fb",
+                                 "../schemas/VisualizationPrimitives_generated.js");
+  return remFiles;
 }
 
 export async function loadRem(s3, bucket, name, remShaderMaterial, animationEngine, callback) {
   const tstart = performance.now();
-  if (remFiles.objectName == null || remFiles.schemaFile == null) {
+  if (!remFiles) {
     console.log("No REM files present")
     return
   }

--- a/demo/rtkLoaderFlatbuffer.js
+++ b/demo/rtkLoaderFlatbuffer.js
@@ -2,28 +2,24 @@
 import { incrementLoadingBarTotal, updateLoadingBar } from "../common/overlay.js";
 import { RtkTrajectory } from "../demo/RtkTrajectory.js";
 import { animateRTK } from "../demo/rtkLoader.js";
-import { } from  "../demo/paramLoader.js"; 
+import { } from  "../demo/paramLoader.js";
 import { loadTexturedCar } from "../demo/textureLoader.js";
-import { existsOrNull } from "./loaderHelper.js"
+import { getFbFileInfo } from "./loaderUtilities.js";
 
-const rtkFiles = {objectName: null, schemaFile: null}
 
+let rtkFiles = null;
 // sets local variable and returns so # files can be counted
 export const rtkFlatbufferDownloads = async (datasetFiles) => {
-  const isLocalLoad = datasetFiles == null
-  const localObj = "../data/rtk.fb";
-  const localSchema = "../schemas/RTK_generated.js";
-  const objNameMatch = "rtk.fb" // 0_Preprocessed
-  const schemaMatch = "RTK_generated.js" // 5_Schemas
-  rtkFiles.objectName = isLocalLoad ?
-    await existsOrNull(localObj) : datasetFiles.filter(path => path.endsWith(objNameMatch))[0]
-  rtkFiles.schemaFile = isLocalLoad ?
-    await existsOrNull(localSchema) : datasetFiles.filter(path => path.endsWith(schemaMatch))[0]
+  rtkFiles = await getFbFileInfo(datasetFiles,
+                                 "rtk.fb", // 0_Preprocessed
+                                 "RTK_generated.js", // 5_Schemas
+                                 "../data/rtk.fb",
+                                 "../schemas/RTK_generated.js");
   return rtkFiles
 }
 
 export async function loadRtkFlatbuffer(s3, bucket, name, callback) {
-  if (rtkFiles.objectName == null || rtkFiles.schemaFile == null) {
+  if (!rtkFiles) {
     console.log("No flatbuffer files present")
     return
   }


### PR DESCRIPTION
This fixes a bug I introduced earlier.
This still crashes the browser while trying to load REM files. But it works
for the things uploaded for lane sense, so let's use it, anyway.
