### PR TITLE
Close the loop: adding support for updating lanes on S3 directly from potree

### DIFF
--- a/common/playbar.js
+++ b/common/playbar.js
@@ -402,3 +402,273 @@ function addPlaybarListeners() {
 		viewer.setFilterGPSTimeExtent(gpsTime + 2.5 * timeMin, gpsTime + 2.5 * timeMax);
 	});
 }
+
+
+function updateLane () {
+  // create lanes flatbuffer
+  const lane = {
+    id: 0,
+    timestamp: [],
+    left: [],
+    right: [],
+    laneTypeLeft: [],
+    laneTypeRight: [],
+    leftPointValidity: [],
+    rightPointValidity: [],
+    leftPointAnnotationStatus: [],
+    rightPointAnnotationStatus: []
+  }
+
+  // Left Lane Vertices:
+  const laneLeftSegments = window.viewer.scene.scene.getChildByName("Left Lane Segments");
+  if (laneLeftSegments === undefined) {
+    const laneLeft = window.viewer.scene.scene.getChildByName("Lane Left");
+    lane.left = laneLeft.points; // download(JSON.stringify(laneLeft.points, null, 2), "lane-left.json");
+  } else {
+    lane.left = laneLeftSegments.getFinalPoints(); // download(JSON.stringify(laneLeftSegments.getFinalPoints(), null, 2), "lane-left.json");
+  }
+
+  // Right Lane Vertices:
+  const laneRightSegments = window.viewer.scene.scene.getChildByName("Right Lane Segments");
+  if (laneRightSegments === undefined) {
+    const laneRight = window.viewer.scene.scene.getChildByName("Lane Right");
+    lane.right = laneRight.points; // download(JSON.stringify(laneRight.points, null, 2), "lane-right.json", "text/plain");
+  } else {
+    lane.right = laneRightSegments.getFinalPoints(); // download(JSON.stringify(laneRightSegments.getFinalPoints(), null, 2), "lane-right.json", "text/plain");
+  }
+
+  // Get New Spine Vertices
+  lane.spine = updateSpine(lane.left, lane.right);
+  // Update Lane attributes to be valid
+  updateLaneHelper(lane);
+
+  const bytes = createLanesFlatbuffer([lane]);
+
+  writeFileToS3(s3, bucket, name, "2_Truth", "upload-testing-lanes.fb", bytes);
+}
+
+export async function writeFileToS3 (s3, bucket, name, subdirectory, filename, buffer) {
+  try {
+    const request = s3.putObject({
+      Bucket: bucket,
+      Key: `${name}/${subdirectory}/${filename}`,
+      Body: buffer
+    });
+    request.on("httpUploadProgress", async (e) => {
+      await updateLoadingBar(e.loaded / e.total * 100)
+    });
+    await request.promise();
+    incrementLoadingBarTotal("lanes uploaded")
+  } catch (e) {
+    console.error("Error: could not write file to S3: ", e);
+  }
+}
+
+function updateLaneHelper (lane) {
+  const spineLength = lane.spine.length;
+  const leftLength = lane.left.length;
+  const rightLength = lane.right.length;
+  lane.timestamp = Array.from({length: spineLength}).map(x => 0.0)
+  lane.leftPointValidity = Array.from({length: leftLength}).map(x => Flatbuffer.GroundTruth.PointValidity(0));
+  lane.rightPointValidity = Array.from({length: rightLength}).map(x => Flatbuffer.GroundTruth.PointValidity(0));
+  lane.leftPointAnnotationStatus = Array.from({ length: leftLength }).map(x => Flatbuffer.GroundTruth.PointAnnotationStatus(0));
+  lane.rightPointAnnotationStatus = Array.from({ length: rightLength }).map(x => Flatbuffer.GroundTruth.PointAnnotationStatus(0));
+}
+
+export function createLanesFlatbuffer (input) {
+  const lanesArray = []
+  const builder = new flatbuffers.flatbuffers.Builder(0);
+  // create each lane and push to lanesArray
+  for (const lane of input.all) {
+    Flatbuffer.GroundTruth.Lane.startLane(builder);
+    Flatbuffer.GroundTruth.Lane.addId(builder, lane.id);
+    Flatbuffer.GroundTruth.Lane.addTimestamp(builder, lane.timestamp);
+    Flatbuffer.GroundTruth.Lane.addLeft(builder, lane.left);
+    Flatbuffer.GroundTruth.Lane.addRight(builder, lane.right);
+    Flatbuffer.GroundTruth.Lane.addlaneTypeLeft(builder, lane.laneTypeLeft);
+    Flatbuffer.GroundTruth.Lane.addLaneTypeRight(builder, lane.laneTypeRight);
+    Flatbuffer.GroundTruth.Lane.addLeftPointValidity(builder, lane.leftPointValidity);
+    Flatbuffer.GroundTruth.Lane.addRightPointValidity(builder, lane.rightPointValidity);
+    Flatbuffer.GroundTruth.Lane.addLeftPointAnnotationStatus(builder, lane.leftPointAnnotationStatus);
+    Flatbuffer.GroundTruth.Lane.addRightPointAnnotationStatus(builder, lane.rightPointAnnotationStatus);
+    const newLane = Flatbuffer.GroundTruth.Lane.endLane(builder);
+    lanesArray.push(newLane)
+  }
+  const lanes = Flatbuffer.GroundTruth.Lanes.createLanesVector(builder, lanesArray);
+  Flatbuffer.GroundTruth.Lanes.finishLanesBuffer(builder, lanes);
+  const bytes = builder.asUint8Array();
+  const lenBytes = new Uint8Array(4);
+  const dv = new DataView(lenBytes.buffer);
+  dv.setUint32(0, bytes.length, true);
+
+  const outbytes = new Int8Array(lenBytes.length + bytes.length);
+  outbytes.set(lenBytes);
+  outbytes.set(bytes, lenBytes.length);
+  return outbytes;
+}
+
+
+function getXYZ(data) {
+    x = data['position']['x'];
+    y = data['position']['y'];
+    z = data['position']['z'];
+    return [x, y, z];
+}
+
+function getHeading(pt1, pt2) {
+    p1 = np.array(pt1).transpose()
+    p2 = np.array(pt2).transpose()
+    delta = p2-p1;
+    heading = Math.atan2(delta[1], delta[0]);
+    return heading;
+}
+
+function minAngle(theta, bounds=[-Math.pi, Math.pi]) {
+    while (theta < bounds[0]) {
+        theta += 2 * Math.pi
+    }
+    while (theta > bounds[1]) {
+        theta -= 2 * Math.pi
+    }
+    return theta;
+}
+
+function minAngleDiff(theta1, theta2, bounds=[-np.pi, np.pi]) {
+    delta = theta2 - theta1;
+    return minAngle(delta);
+}
+
+function normalizeVector(vector) {
+    vector = Array(vector);
+    return vector / math.norm(vector)
+}
+
+
+function find_plane_line_intersection(plane_pt, plane_normal, line_pt, line_direction) {
+    plane_normal = normalizeVector(plane_normal);
+    line_direction = normalizeVector(line_direction);
+
+    alpha = math.dot(plane_normal, plane_pt) - math.dot(plane_normal, line_pt) / math.dot(plane_normal, line_direction)
+    return line_pt + alpha * line_direction;
+}
+
+
+function updateSpine (laneLefts, laneRights) {
+    laneChangeNNRange = 5 // meters
+    rightLaneNeighborPointsQueryNumber = 10 // number of neighbors
+    laneChangeHeadingThresh = np.pi/4 // Radians
+    prevPointSuppressionRadius = .1 // meters
+    // Compute Spine Vertices (using left lane as reference):
+    // PROBLEM: No shapely libary in JS need to find alternative as we need interpolation and projection functions below
+    rightLine = LineString(laneRights) // Create shapely linestring for right line
+    // PROBLEM no built in libraries for this one either. Can build tree structure on our own though
+    kdtree = cKDTree(laneRights) // Create KD-Tree for right lane points as well
+    lastIdx = len(laneLefts)-1
+    for (let ii = 0; ii < lastIdx+1; ii++) {
+        p = laneLefts[ii];
+        pt = Point(p);
+        projPt = rightLine.interpolate(rightLine.project(pt));
+        minLine = LineString([pt, projPt]) // Shortest line from pt to right line
+        spinePt = minLine.interpolate(minLine.length / 2)
+
+        if (ii !== 0 && ii !== lastIdx) {
+            lastPt = Point(laneLefts[ii-1]);
+            nextPt = Point(laneLefts[ii+1]);
+            lastHeading = getHeading(lastPt, pt);
+            nextHeading = getHeading(pt, nextPt);
+
+            leftHeadingDelta = minAngleDiff(lastHeading, nextHeading);
+
+            if (Math.abs(leftHeadingDelta) > laneChangeHeadingThresh) {
+
+                // Get idxs of nearby right points
+                dists_nn, idxs_nn = kdtree.query(p, rightLaneNeighborPointsQueryNumber)
+
+                filterer = dists_nn <= laneChangeNNRange;
+                dists_nn = dists_nn[filterer];
+                idxs_nn = idxs_nn[filterer];
+
+                if (idxs_nn.length === 0) { continue }
+
+                idxs_nn_min = Math.max(idxs_nn.min()-1, 0)
+                idxs_nn_max = Math.min(idxs_nn.max()+2, laneRights.length)
+
+                idxs_nn = np.arange(idxs_nn_min, idxs_nn_max) // Closed set of points approximately within laneChangeNNRange of pt
+
+                if (idxs_nn.length < 3) {
+                    console.log(`Not Enough Neighbors for pt: [idx: ${ii}, pos: ${p}]`);
+                    continue
+                }
+                // Find closest lane change point in right line:
+                rightPts = Array(laneRights)[idxs_nn]
+                rightPtDeltas = np.diff(rightPts, axis=0)
+                rightHeadings = Math.atan2(rightPtDeltas[:,1], rightPtDeltas[:,0])
+                rightHeadingDeltas = Array([minAngle(x) for x in np.diff(rightHeadings)])
+
+
+                if (rightHeadingDeltas.shape[0] == 0) {
+                    console.log(`No RightHeadingDeltas for pt: [idx: ${ii}, pos: ${p}]`);
+                    continue
+                }
+                leftRightHeadingDeltaSimilarity = Math.abs(rightHeadingDeltas-leftHeadingDelta)
+                bestRightHeadingIdx = leftRightHeadingDeltaSimilarity.argmin() + 1
+                rightPtIdx = idxs_nn[bestRightHeadingIdx] // +1 inside []
+
+                // Simple Solution (Just Compute Spine Point using the Right Lane Change Point and append):
+                rightPt = Point(laneRights[rightPtIdx])
+                minLine = LineString([pt, rightPt])
+                spinePt2 = minLine.interpolate(minLine.length / 2)
+
+                p1 = Array(laneSpines[-1].slice(2)])
+                p2 = Array(spinePt2.xy).flatten()
+
+                if (math.norm((p2-p1)) > prevPointSuppressionRadius) { // If spine point is farther than thresh from previous point append
+                    laneSpines.push([spinePt2.x, spinePt2.y, spinePt2.z])
+                }
+            }
+        }
+        // Don't append lane spine if duplicate (within 10cm of last) or if going backwards:
+        function should_append(spinePt) {
+
+            if (laneSpines.length < 1) {
+                return true;
+            }
+
+            // TODO double check with original
+            p1 = Array(laneSpines[-1]).slice(2);
+            p2 = Array(spinePt.xy).flatten()
+
+            if (np.linalg.norm(p2-p1) < prevPointSuppressionRadius) {
+                console.log("Skipping lane spine point-- too close to existing spine point");
+                return false;
+            } else {
+                if (laneSpines.length >=2) {
+                    p0 = Array(laneSpines[-2]).slice(2);
+
+                    v1 = (p1-p0).slice(2);
+                    v2 = (p2-p1).slice(2);
+
+                    magV1 = math.norm(v1)
+                    magV2 = math.norm(v2)
+
+                    cosHeading = math.dot(v1, v2)/(magV1 * magV2)
+
+                    if (Math.abs(cosHeading - (-1)) < .1) {
+                        console.log("Skipping lane spine point -- going backwards");
+                        return false;
+                    } else {
+                        return true;
+                    }
+                } else {
+                    return true;
+                }
+            }
+        } //end function should_append
+
+        if (should_append(spinePt)) {
+            laneSpines.push([spinePt.x, spinePt.y, spinePt.z])
+        }
+    }
+    // laneSpines = Array(laneSpines[laneSpines.length])
+    return laneSpines
+}

--- a/common/playbar.js
+++ b/common/playbar.js
@@ -1,5 +1,9 @@
 'use strict';
 
+import { bucket, name, s3 } from "../demo/paramLoader.js";
+import { writeFileToS3, createLanesFlatbufferBytes } from "../demo/loaderUtilities.js";
+
+
 const numberOrZero = (string) => {
   const value = Number(string);
   return isNaN(value) ? 0 : value;
@@ -156,40 +160,41 @@ export function createPlaybar () {
         document.body.removeChild(element);
       }
 
-      // Download Left Lane Vertices:
-      try {
-        const laneLeftSegments = window.viewer.scene.scene.getChildByName("Left Lane Segments");
-        if (laneLeftSegments == undefined) {
-          const laneLeft = window.viewer.scene.scene.getChildByName("Lane Left");
-          download(JSON.stringify(laneLeft.points, null, 2), "lane-left.json");
-        } else {
-          download(JSON.stringify(laneLeftSegments.getFinalPoints(), null, 2), "lane-left.json");
-        }
-
-      } catch (e) {
-        console.error("Couldn't download left lane vertices: ", e);
-      }
-
-      // Download Lane Spine Vertices:
-      try {
-        const laneSpine = window.viewer.scene.scene.getChildByName("Lane Spine");
-        download(JSON.stringify(laneSpine.points, null, 2), "lane-spine.json", "text/plain");
-      } catch (e) {
-        console.error("Couldn't download lane spine vertices: ", e);
-      }
-
-      // Download Right Lane Vertices:
-      try {
-        const laneRightSegments = window.viewer.scene.scene.getChildByName("Right Lane Segments");
-        if (laneRightSegments == undefined) {
-          const laneRight = window.viewer.scene.scene.getChildByName("Lane Right");
-          download(JSON.stringify(laneRight.points, null, 2), "lane-right.json", "text/plain");
-        } else {
-          download(JSON.stringify(laneRightSegments.getFinalPoints(), null, 2), "lane-right.json", "text/plain");
-        }
-      } catch (e) {
-        console.error("Couldn't download right lane vertices: ", e);
-      }
+  updateLane();
+      // // Download Left Lane Vertices:
+      // try {
+      //   const laneLeftSegments = window.viewer.scene.scene.getChildByName("Left Lane Segments");
+      //   if (laneLeftSegments == undefined) {
+      //     const laneLeft = window.viewer.scene.scene.getChildByName("Lane Left");
+      //     download(JSON.stringify(laneLeft.points, null, 2), "lane-left.json");
+      //   } else {
+      //     download(JSON.stringify(laneLeftSegments.getFinalPoints(), null, 2), "lane-left.json");
+      //   }
+  //
+      // } catch (e) {
+      //   console.error("Couldn't download left lane vertices: ", e);
+      // }
+  //
+      // // Download Lane Spine Vertices:
+      // try {
+      //   const laneSpine = window.viewer.scene.scene.getChildByName("Lane Spine");
+      //   download(JSON.stringify(laneSpine.points, null, 2), "lane-spine.json", "text/plain");
+      // } catch (e) {
+      //   console.error("Couldn't download lane spine vertices: ", e);
+      // }
+  //
+      // // Download Right Lane Vertices:
+      // try {
+      //   const laneRightSegments = window.viewer.scene.scene.getChildByName("Right Lane Segments");
+      //   if (laneRightSegments == undefined) {
+      //     const laneRight = window.viewer.scene.scene.getChildByName("Lane Right");
+      //     download(JSON.stringify(laneRight.points, null, 2), "lane-right.json", "text/plain");
+      //   } else {
+      //     download(JSON.stringify(laneRightSegments.getFinalPoints(), null, 2), "lane-right.json", "text/plain");
+      //   }
+      // } catch (e) {
+      //   console.error("Couldn't download right lane vertices: ", e);
+      // }
 
 
 
@@ -222,58 +227,58 @@ export function createPlaybar () {
     document.getElementById("load_gaps_button").style.display = "none";
     document.getElementById("download_lanes_button").style.display = "none";
 
-	// originall from radar.html
-	document.getElementById("playbar_tmax").disabled = false;
-	document.getElementById("playbar_tmin").disabled = false;
-	document.getElementById("elevation_max").display = false;
-	document.getElementById("elevation_min").disabled = false;
+  // originall from radar.html
+  document.getElementById("playbar_tmax").disabled = false;
+  document.getElementById("playbar_tmin").disabled = false;
+  document.getElementById("elevation_max").display = false;
+  document.getElementById("elevation_min").disabled = false;
 
-	window.truthAnnotationMode = 0;	// 0: None, 1: Delete, 2: Add
-	let annotationScreen = $(`<div id="annotationScreen"><p id="annotation-label">ANNOTATION MODE: <b id="annotation-mode-text"></b></p></div>`);
-	$('body').prepend(annotationScreen);
-	let div = document.getElementById("annotationScreen");
-	div.style.opacity=0;
+  window.truthAnnotationMode = 0;	// 0: None, 1: Delete, 2: Add
+  let annotationScreen = $(`<div id="annotationScreen"><p id="annotation-label">ANNOTATION MODE: <b id="annotation-mode-text"></b></p></div>`);
+  $('body').prepend(annotationScreen);
+  let div = document.getElementById("annotationScreen");
+  div.style.opacity=0;
 
-	// event listeners
-	window.addEventListener('keydown', (e) => {
-		if (window.annotateLanesModeActive) {
-			if (e.code == "KeyA") {
-				window.truthAnnotationMode = 2;
-			} else if (e.code == "KeyS") {
-				window.truthAnnotationMode = 1;
-			} else if (e.shiftKey) {
-				window.truthAnnotationMode = (window.truthAnnotationMode + 1) % 3;
-			}
+  // event listeners
+  window.addEventListener('keydown', (e) => {
+  if (window.annotateLanesModeActive) {
+  if (e.code == "KeyA") {
+  window.truthAnnotationMode = 2;
+  } else if (e.code == "KeyS") {
+  window.truthAnnotationMode = 1;
+  } else if (e.shiftKey) {
+  window.truthAnnotationMode = (window.truthAnnotationMode + 1) % 3;
+  }
 
-			let div = document.getElementById("annotationScreen");
-			let label = document.getElementById("annotation-mode-text");
-			if (window.truthAnnotationMode == 0) {
-				div.style.background = "black";
-				div.style.opacity=0;
-				label.innerHTML = "NONE";
-			}
-			else if (window.truthAnnotationMode == 1) {
-				div.style.background = "red";
-				div.style.opacity=0.25;
-				label.innerHTML = "DELETE POINTS";
-			} else if (window.truthAnnotationMode == 2) {
-				div.style.background = "green";
-				div.style.opacity=0.25;
-				label.innerHTML = "ADD POINTS";
-			}
-		}
-	});
+  let div = document.getElementById("annotationScreen");
+  let label = document.getElementById("annotation-mode-text");
+  if (window.truthAnnotationMode == 0) {
+  div.style.background = "black";
+  div.style.opacity=0;
+  label.innerHTML = "NONE";
+  }
+  else if (window.truthAnnotationMode == 1) {
+  div.style.background = "red";
+  div.style.opacity=0.25;
+  label.innerHTML = "DELETE POINTS";
+  } else if (window.truthAnnotationMode == 2) {
+  div.style.background = "green";
+  div.style.opacity=0.25;
+  label.innerHTML = "ADD POINTS";
+  }
+  }
+  });
 
-	window.addEventListener("keyup", (e) => {
-		if (window.annotateLanesModeActive) {
-			window.truthAnnotationMode = 0;
-			let div = document.getElementById("annotationScreen");
-			let label = document.getElementById("annotation-mode-text");
-			div.style.background = "black";
-			div.style.opacity=0;
-			label.innerHTML = "NONE";
-		}
-	});
+  window.addEventListener("keyup", (e) => {
+  if (window.annotateLanesModeActive) {
+  window.truthAnnotationMode = 0;
+  let div = document.getElementById("annotationScreen");
+  let label = document.getElementById("annotation-mode-text");
+  div.style.background = "black";
+  div.style.opacity=0;
+  label.innerHTML = "NONE";
+  }
+  });
   addPlaybarListeners();
 }
 
@@ -302,23 +307,23 @@ function addPlaybarListeners() {
         animationEngine.start();
     });
 
-	// Pre-Start/Stop Callbacks
-	animationEngine.preStartCallback = function () {
-		if (!animationEngine.isPlaying) {
-			$("#playbutton").trigger("mousedown");
-		}
-	}
+  // Pre-Start/Stop Callbacks
+  animationEngine.preStartCallback = function () {
+  if (!animationEngine.isPlaying) {
+  $("#playbutton").trigger("mousedown");
+  }
+  }
 
-	animationEngine.preStopCallback = function () {
-		if (animationEngine.isPlaying) {
-			$("#pausebutton").trigger("mousedown");
-		}
-	}
+  animationEngine.preStopCallback = function () {
+  if (animationEngine.isPlaying) {
+  $("#pausebutton").trigger("mousedown");
+  }
+  }
 
-	// Playbar:
+  // Playbar:
     animationEngine.tweenTargets.push((gpsTime, updateDisplayedTime) => {
-	  let t = (gpsTime - animationEngine.tstart) / (animationEngine.timeRange);
-	  slider.value = 100*t;
+    let t = (gpsTime - animationEngine.tstart) / (animationEngine.timeRange);
+    slider.value = 100*t;
 
           // If this change came from typing, don't rewrite it.
           if (updateDisplayedTime) {
@@ -326,24 +331,24 @@ function addPlaybarListeners() {
           }
     });
 
-	// Camera:
-	// let updateCamera = false;
-	// let lag = 1.01; // seconds
-	// let camPointZOffset = 10; // meters
-	// window.camControlInitialized = false;
-	// window.camPointNeedsToBeComputed = true;
-	// window.camControlInUse = false;
-	// window.camDeltaTransform = {camStart: new THREE.Matrix4(), vehicleStart: new THREE.Vector3(), camEnd: new THREE.Matrix4(), vehicleEnd: new THREE.Vector3()};
-	// window.camPointLocalFrame = {position: new THREE.Vector3(-10,0,10)};
-	// window.camTargetLocalFrame = {position: new THREE.Vector3(0, 0, 0)};
-	viewer.renderArea.addEventListener("keypress", (e) => {
-		if (e.key == "r") {
-			let box = new THREE.Box3().setFromObject(viewer.scene.scene.getObjectByName("Vehicle").getObjectByName("Vehicle Mesh"));
-			let node = new THREE.Object3D();
-			node.boundingBox = box;
-			viewer.zoomTo(node, 5, 500);
-		}
-	});
+  // Camera:
+  // let updateCamera = false;
+  // let lag = 1.01; // seconds
+  // let camPointZOffset = 10; // meters
+  // window.camControlInitialized = false;
+  // window.camPointNeedsToBeComputed = true;
+  // window.camControlInUse = false;
+  // window.camDeltaTransform = {camStart: new THREE.Matrix4(), vehicleStart: new THREE.Vector3(), camEnd: new THREE.Matrix4(), vehicleEnd: new THREE.Vector3()};
+  // window.camPointLocalFrame = {position: new THREE.Vector3(-10,0,10)};
+  // window.camTargetLocalFrame = {position: new THREE.Vector3(0, 0, 0)};
+  viewer.renderArea.addEventListener("keypress", (e) => {
+  if (e.key == "r") {
+  let box = new THREE.Box3().setFromObject(viewer.scene.scene.getObjectByName("Vehicle").getObjectByName("Vehicle Mesh"));
+  let node = new THREE.Object3D();
+  node.boundingBox = box;
+  viewer.zoomTo(node, 5, 500);
+  }
+  });
 
     time_display.addEventListener('input',
                                   e => {
@@ -392,25 +397,26 @@ function addPlaybarListeners() {
       animationEngine.updateTimeForAll();
     });
 
-	// PointCloud:
-	animationEngine.tweenTargets.push((gpsTime) => {
-		// debugger; // account for pointcloud offset
+  // PointCloud:
+  animationEngine.tweenTargets.push((gpsTime) => {
+  // debugger; // account for pointcloud offset
                 const {backward, forward} = animationEngine.activeWindow;
                 const timeMin = numberOrZero(backward);
                 const timeMax = numberOrZero(forward);
-		viewer.setFilterGPSTimeRange(gpsTime + timeMin, gpsTime + timeMax);
-		viewer.setFilterGPSTimeExtent(gpsTime + 2.5 * timeMin, gpsTime + 2.5 * timeMax);
-	});
+  viewer.setFilterGPSTimeRange(gpsTime + timeMin, gpsTime + timeMax);
+  viewer.setFilterGPSTimeExtent(gpsTime + 2.5 * timeMin, gpsTime + 2.5 * timeMax);
+  });
 }
 
 
-function updateLane () {
+async function updateLane () {
   // create lanes flatbuffer
   const lane = {
     id: 0,
     timestamp: [],
     left: [],
     right: [],
+    spine: [],
     laneTypeLeft: [],
     laneTypeRight: [],
     leftPointValidity: [],
@@ -424,6 +430,7 @@ function updateLane () {
   if (laneLeftSegments === undefined) {
     const laneLeft = window.viewer.scene.scene.getChildByName("Lane Left");
     lane.left = laneLeft.points; // download(JSON.stringify(laneLeft.points, null, 2), "lane-left.json");
+    console.log("left", lane.left);
   } else {
     lane.left = laneLeftSegments.getFinalPoints(); // download(JSON.stringify(laneLeftSegments.getFinalPoints(), null, 2), "lane-left.json");
   }
@@ -438,237 +445,30 @@ function updateLane () {
   }
 
   // Get New Spine Vertices
-  lane.spine = updateSpine(lane.left, lane.right);
+  // lane.spine = updateSpine(lane.left, lane.right);
   // Update Lane attributes to be valid
-  updateLaneHelper(lane);
 
-  const bytes = createLanesFlatbuffer([lane]);
+  const schemaUrl = s3.getSignedUrl('getObject', {
+    Bucket: bucket,
+    Key: `${name}/5_Schemas/GroundTruth_generated.js`
+  });
+  const FlatbufferModule = await import(schemaUrl);
 
+  await updateLaneHelper(lane, FlatbufferModule);
+
+  const bytes = await createLanesFlatbufferBytes(lane, FlatbufferModule);
+  console.log("bytes", bytes);
   writeFileToS3(s3, bucket, name, "2_Truth", "upload-testing-lanes.fb", bytes);
 }
 
-export async function writeFileToS3 (s3, bucket, name, subdirectory, filename, buffer) {
-  try {
-    const request = s3.putObject({
-      Bucket: bucket,
-      Key: `${name}/${subdirectory}/${filename}`,
-      Body: buffer
-    });
-    request.on("httpUploadProgress", async (e) => {
-      await updateLoadingBar(e.loaded / e.total * 100)
-    });
-    await request.promise();
-    incrementLoadingBarTotal("lanes uploaded")
-  } catch (e) {
-    console.error("Error: could not write file to S3: ", e);
-  }
-}
-
-function updateLaneHelper (lane) {
+async function updateLaneHelper (lane, FlatbufferModule) {
   const spineLength = lane.spine.length;
   const leftLength = lane.left.length;
   const rightLength = lane.right.length;
-  lane.timestamp = Array.from({length: spineLength}).map(x => 0.0)
-  lane.leftPointValidity = Array.from({length: leftLength}).map(x => Flatbuffer.GroundTruth.PointValidity(0));
-  lane.rightPointValidity = Array.from({length: rightLength}).map(x => Flatbuffer.GroundTruth.PointValidity(0));
-  lane.leftPointAnnotationStatus = Array.from({ length: leftLength }).map(x => Flatbuffer.GroundTruth.PointAnnotationStatus(0));
-  lane.rightPointAnnotationStatus = Array.from({ length: rightLength }).map(x => Flatbuffer.GroundTruth.PointAnnotationStatus(0));
-}
 
-export function createLanesFlatbuffer (input) {
-  const lanesArray = []
-  const builder = new flatbuffers.flatbuffers.Builder(0);
-  // create each lane and push to lanesArray
-  for (const lane of input.all) {
-    Flatbuffer.GroundTruth.Lane.startLane(builder);
-    Flatbuffer.GroundTruth.Lane.addId(builder, lane.id);
-    Flatbuffer.GroundTruth.Lane.addTimestamp(builder, lane.timestamp);
-    Flatbuffer.GroundTruth.Lane.addLeft(builder, lane.left);
-    Flatbuffer.GroundTruth.Lane.addRight(builder, lane.right);
-    Flatbuffer.GroundTruth.Lane.addlaneTypeLeft(builder, lane.laneTypeLeft);
-    Flatbuffer.GroundTruth.Lane.addLaneTypeRight(builder, lane.laneTypeRight);
-    Flatbuffer.GroundTruth.Lane.addLeftPointValidity(builder, lane.leftPointValidity);
-    Flatbuffer.GroundTruth.Lane.addRightPointValidity(builder, lane.rightPointValidity);
-    Flatbuffer.GroundTruth.Lane.addLeftPointAnnotationStatus(builder, lane.leftPointAnnotationStatus);
-    Flatbuffer.GroundTruth.Lane.addRightPointAnnotationStatus(builder, lane.rightPointAnnotationStatus);
-    const newLane = Flatbuffer.GroundTruth.Lane.endLane(builder);
-    lanesArray.push(newLane)
-  }
-  const lanes = Flatbuffer.GroundTruth.Lanes.createLanesVector(builder, lanesArray);
-  Flatbuffer.GroundTruth.Lanes.finishLanesBuffer(builder, lanes);
-  const bytes = builder.asUint8Array();
-  const lenBytes = new Uint8Array(4);
-  const dv = new DataView(lenBytes.buffer);
-  dv.setUint32(0, bytes.length, true);
-
-  const outbytes = new Int8Array(lenBytes.length + bytes.length);
-  outbytes.set(lenBytes);
-  outbytes.set(bytes, lenBytes.length);
-  return outbytes;
-}
-
-
-function getXYZ(data) {
-    x = data['position']['x'];
-    y = data['position']['y'];
-    z = data['position']['z'];
-    return [x, y, z];
-}
-
-function getHeading(pt1, pt2) {
-    p1 = np.array(pt1).transpose()
-    p2 = np.array(pt2).transpose()
-    delta = p2-p1;
-    heading = Math.atan2(delta[1], delta[0]);
-    return heading;
-}
-
-function minAngle(theta, bounds=[-Math.pi, Math.pi]) {
-    while (theta < bounds[0]) {
-        theta += 2 * Math.pi
-    }
-    while (theta > bounds[1]) {
-        theta -= 2 * Math.pi
-    }
-    return theta;
-}
-
-function minAngleDiff(theta1, theta2, bounds=[-np.pi, np.pi]) {
-    delta = theta2 - theta1;
-    return minAngle(delta);
-}
-
-function normalizeVector(vector) {
-    vector = Array(vector);
-    return vector / math.norm(vector)
-}
-
-
-function find_plane_line_intersection(plane_pt, plane_normal, line_pt, line_direction) {
-    plane_normal = normalizeVector(plane_normal);
-    line_direction = normalizeVector(line_direction);
-
-    alpha = math.dot(plane_normal, plane_pt) - math.dot(plane_normal, line_pt) / math.dot(plane_normal, line_direction)
-    return line_pt + alpha * line_direction;
-}
-
-
-function updateSpine (laneLefts, laneRights) {
-    laneChangeNNRange = 5 // meters
-    rightLaneNeighborPointsQueryNumber = 10 // number of neighbors
-    laneChangeHeadingThresh = np.pi/4 // Radians
-    prevPointSuppressionRadius = .1 // meters
-    // Compute Spine Vertices (using left lane as reference):
-    // PROBLEM: No shapely libary in JS need to find alternative as we need interpolation and projection functions below
-    rightLine = LineString(laneRights) // Create shapely linestring for right line
-    // PROBLEM no built in libraries for this one either. Can build tree structure on our own though
-    kdtree = cKDTree(laneRights) // Create KD-Tree for right lane points as well
-    lastIdx = len(laneLefts)-1
-    for (let ii = 0; ii < lastIdx+1; ii++) {
-        p = laneLefts[ii];
-        pt = Point(p);
-        projPt = rightLine.interpolate(rightLine.project(pt));
-        minLine = LineString([pt, projPt]) // Shortest line from pt to right line
-        spinePt = minLine.interpolate(minLine.length / 2)
-
-        if (ii !== 0 && ii !== lastIdx) {
-            lastPt = Point(laneLefts[ii-1]);
-            nextPt = Point(laneLefts[ii+1]);
-            lastHeading = getHeading(lastPt, pt);
-            nextHeading = getHeading(pt, nextPt);
-
-            leftHeadingDelta = minAngleDiff(lastHeading, nextHeading);
-
-            if (Math.abs(leftHeadingDelta) > laneChangeHeadingThresh) {
-
-                // Get idxs of nearby right points
-                dists_nn, idxs_nn = kdtree.query(p, rightLaneNeighborPointsQueryNumber)
-
-                filterer = dists_nn <= laneChangeNNRange;
-                dists_nn = dists_nn[filterer];
-                idxs_nn = idxs_nn[filterer];
-
-                if (idxs_nn.length === 0) { continue }
-
-                idxs_nn_min = Math.max(idxs_nn.min()-1, 0)
-                idxs_nn_max = Math.min(idxs_nn.max()+2, laneRights.length)
-
-                idxs_nn = np.arange(idxs_nn_min, idxs_nn_max) // Closed set of points approximately within laneChangeNNRange of pt
-
-                if (idxs_nn.length < 3) {
-                    console.log(`Not Enough Neighbors for pt: [idx: ${ii}, pos: ${p}]`);
-                    continue
-                }
-                // Find closest lane change point in right line:
-                rightPts = Array(laneRights)[idxs_nn]
-                rightPtDeltas = np.diff(rightPts, axis=0)
-                rightHeadings = Math.atan2(rightPtDeltas[:,1], rightPtDeltas[:,0])
-                rightHeadingDeltas = Array([minAngle(x) for x in np.diff(rightHeadings)])
-
-
-                if (rightHeadingDeltas.shape[0] == 0) {
-                    console.log(`No RightHeadingDeltas for pt: [idx: ${ii}, pos: ${p}]`);
-                    continue
-                }
-                leftRightHeadingDeltaSimilarity = Math.abs(rightHeadingDeltas-leftHeadingDelta)
-                bestRightHeadingIdx = leftRightHeadingDeltaSimilarity.argmin() + 1
-                rightPtIdx = idxs_nn[bestRightHeadingIdx] // +1 inside []
-
-                // Simple Solution (Just Compute Spine Point using the Right Lane Change Point and append):
-                rightPt = Point(laneRights[rightPtIdx])
-                minLine = LineString([pt, rightPt])
-                spinePt2 = minLine.interpolate(minLine.length / 2)
-
-                p1 = Array(laneSpines[-1].slice(2)])
-                p2 = Array(spinePt2.xy).flatten()
-
-                if (math.norm((p2-p1)) > prevPointSuppressionRadius) { // If spine point is farther than thresh from previous point append
-                    laneSpines.push([spinePt2.x, spinePt2.y, spinePt2.z])
-                }
-            }
-        }
-        // Don't append lane spine if duplicate (within 10cm of last) or if going backwards:
-        function should_append(spinePt) {
-
-            if (laneSpines.length < 1) {
-                return true;
-            }
-
-            // TODO double check with original
-            p1 = Array(laneSpines[-1]).slice(2);
-            p2 = Array(spinePt.xy).flatten()
-
-            if (np.linalg.norm(p2-p1) < prevPointSuppressionRadius) {
-                console.log("Skipping lane spine point-- too close to existing spine point");
-                return false;
-            } else {
-                if (laneSpines.length >=2) {
-                    p0 = Array(laneSpines[-2]).slice(2);
-
-                    v1 = (p1-p0).slice(2);
-                    v2 = (p2-p1).slice(2);
-
-                    magV1 = math.norm(v1)
-                    magV2 = math.norm(v2)
-
-                    cosHeading = math.dot(v1, v2)/(magV1 * magV2)
-
-                    if (Math.abs(cosHeading - (-1)) < .1) {
-                        console.log("Skipping lane spine point -- going backwards");
-                        return false;
-                    } else {
-                        return true;
-                    }
-                } else {
-                    return true;
-                }
-            }
-        } //end function should_append
-
-        if (should_append(spinePt)) {
-            laneSpines.push([spinePt.x, spinePt.y, spinePt.z])
-        }
-    }
-    // laneSpines = Array(laneSpines[laneSpines.length])
-    return laneSpines
+  lane.timestamp = Array.from({ length: spineLength }).map(x => 0.0)
+  lane.leftPointValidity = Array.from({ length: leftLength }).map(x => 0);
+  lane.rightPointValidity = Array.from({ length: rightLength }).map(x => 0);
+  lane.leftPointAnnotationStatus = Array.from({ length: leftLength }).map(x => 0);
+  lane.rightPointAnnotationStatus = Array.from({ length: rightLength }).map(x => 0);
 }

--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -616,9 +616,13 @@ export function addReloadLanesButton() {
 	if (window.annotateLanesModeActive) {
 	  reload_lanes_button.innerText = "View Truth Lanes";
 	  document.getElementById("download_lanes_button").style.display = "block";
+    document.getElementById("save_lanes_button").style.display = "block";
+
 	} else {
 	  reload_lanes_button.innerText = "Annotate Truth Lanes";
 	  document.getElementById("download_lanes_button").style.display = "none";
+    document.getElementById("save_lanes_button").style.display = "none";
+
 	}
 
 	reloadLanesButton.disabled = false

--- a/demo/loaderUtilities.js
+++ b/demo/loaderUtilities.js
@@ -129,9 +129,7 @@ export async function writeFileToS3 (s3, bucket, name, subdirectory, filename, b
   }
 }
 
-export async function createLanesFlatbufferBytes (lane, FlatbufferModule) {
-
-  console.log("lane", lane);
+export async function createLanesFlatbuffer (lane, FlatbufferModule) {
   const builder = new flatbuffers.Builder(0);
 
   // Add left vec3s

--- a/demo/loaderUtilities.js
+++ b/demo/loaderUtilities.js
@@ -130,26 +130,28 @@ export async function writeFileToS3 (s3, bucket, name, subdirectory, filename, b
 }
 
 export async function createLanesFlatbufferBytes (lane, FlatbufferModule) {
+
+  console.log("lane", lane);
   const builder = new flatbuffers.Builder(0);
 
   // Add left vec3s
   FlatbufferModule.Flatbuffer.GroundTruth.Lane.startLeftVector(builder, lane.left.length);
   for (const point of lane.left) {
-    FlatbufferModule.Flatbuffer.GroundTruth.Vec3.createVec3(builder, point.x, point.y, point.z);
+    FlatbufferModule.Flatbuffer.GroundTruth.Vec3.createVec3(builder, point.position.x, point.position.y, point.position.z);
   }
   const leftOffset = builder.endVector();
 
   // Add right vec3s
   FlatbufferModule.Flatbuffer.GroundTruth.Lane.startRightVector(builder, lane.right.length);
   for (const point of lane.right) {
-    FlatbufferModule.Flatbuffer.GroundTruth.Vec3.createVec3(builder, point.x, point.y, point.z);
+    FlatbufferModule.Flatbuffer.GroundTruth.Vec3.createVec3(builder, point.position.x, point.position.y, point.position.z);
   }
   const rightOffset = builder.endVector();
 
   // Add spine vec3s
   FlatbufferModule.Flatbuffer.GroundTruth.Lane.startSpineVector(builder, lane.spine.length);
   for (const point of lane.spine) {
-    FlatbufferModule.Flatbuffer.GroundTruth.Vec3.createVec3(builder, point.x, point.y, point.z);
+    FlatbufferModule.Flatbuffer.GroundTruth.Vec3.createVec3(builder, point.position.x, point.position.y, point.position.z);
   }
   const spineOffset = builder.endVector();
 

--- a/demo/loaderUtilities.js
+++ b/demo/loaderUtilities.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { updateLoadingBar, incrementLoadingBarTotal } from "../common/overlay.js";
+
 
 /**
  * @brief Helper function for loaders to determine if a local point cloud file exists
@@ -108,4 +110,80 @@ export function applyRotation(obj, roll, pitch, yaw) {
   obj.rotation.setFromRotationMatrix(rotMat);
 
 
+}
+
+export async function writeFileToS3 (s3, bucket, name, subdirectory, filename, buffer) {
+  try {
+    const request = s3.putObject({
+      Bucket: bucket,
+      Key: `${name}/${subdirectory}/${filename}`,
+      Body: buffer
+    });
+    request.on("httpUploadProgress", async (e) => {
+      // await updateLoadingBar(e.loaded / e.total * 100)
+    });
+    await request.promise();
+    // incrementLoadingBarTotal(`${filename} uploaded`)
+  } catch (e) {
+    console.error("Error: could not write file to S3: ", e);
+  }
+}
+
+export async function createLanesFlatbufferBytes (lane, FlatbufferModule) {
+  const builder = new flatbuffers.Builder(0);
+
+  // Add left vec3s
+  FlatbufferModule.Flatbuffer.GroundTruth.Lane.startLeftVector(builder, lane.left.length);
+  for (const point of lane.left) {
+    FlatbufferModule.Flatbuffer.GroundTruth.Vec3.createVec3(builder, point.x, point.y, point.z);
+  }
+  const leftOffset = builder.endVector();
+
+  // Add right vec3s
+  FlatbufferModule.Flatbuffer.GroundTruth.Lane.startRightVector(builder, lane.right.length);
+  for (const point of lane.right) {
+    FlatbufferModule.Flatbuffer.GroundTruth.Vec3.createVec3(builder, point.x, point.y, point.z);
+  }
+  const rightOffset = builder.endVector();
+
+  // Add spine vec3s
+  FlatbufferModule.Flatbuffer.GroundTruth.Lane.startSpineVector(builder, lane.spine.length);
+  for (const point of lane.spine) {
+    FlatbufferModule.Flatbuffer.GroundTruth.Vec3.createVec3(builder, point.x, point.y, point.z);
+  }
+  const spineOffset = builder.endVector();
+
+  const timestampOffset = FlatbufferModule.Flatbuffer.GroundTruth.Lane.createTimestampVector(builder, lane.timestamp);
+  const laneTypeLeftOffset = FlatbufferModule.Flatbuffer.GroundTruth.Lane.createLaneTypeLeftVector(builder, lane.laneTypeLeft);
+  const laneTypeRightOffset = FlatbufferModule.Flatbuffer.GroundTruth.Lane.createLaneTypeLeftVector(builder, lane.laneTypeRight);
+  const leftPointValidityOffset = FlatbufferModule.Flatbuffer.GroundTruth.Lane.createLeftPointValidityVector(builder, lane.leftPointValidity);
+  const rightPointValidityOffset = FlatbufferModule.Flatbuffer.GroundTruth.Lane.createRightPointValidityVector(builder, lane.rightPointValidity);
+  const leftPointAnnotationStatusOffset = FlatbufferModule.Flatbuffer.GroundTruth.Lane.createLeftPointAnnotationStatusVector(builder, lane.leftPointAnnotationStatus);
+  const rightPointAnnotationStatusOffset = FlatbufferModule.Flatbuffer.GroundTruth.Lane.createRightPointAnnotationStatusVector(builder, lane.rightPointAnnotationStatus);
+
+  // Create lane flatbuffer
+  FlatbufferModule.Flatbuffer.GroundTruth.Lane.startLane(builder);
+  FlatbufferModule.Flatbuffer.GroundTruth.Lane.addId(builder, lane.id);
+  FlatbufferModule.Flatbuffer.GroundTruth.Lane.addTimestamp(builder, timestampOffset);
+  FlatbufferModule.Flatbuffer.GroundTruth.Lane.addLeft(builder, leftOffset);
+  FlatbufferModule.Flatbuffer.GroundTruth.Lane.addRight(builder, rightOffset);
+  FlatbufferModule.Flatbuffer.GroundTruth.Lane.addSpine(builder, spineOffset);
+  FlatbufferModule.Flatbuffer.GroundTruth.Lane.addLaneTypeLeft(builder, laneTypeLeftOffset);
+  FlatbufferModule.Flatbuffer.GroundTruth.Lane.addLaneTypeRight(builder, laneTypeRightOffset);
+  FlatbufferModule.Flatbuffer.GroundTruth.Lane.addLeftPointValidity(builder, leftPointValidityOffset);
+  FlatbufferModule.Flatbuffer.GroundTruth.Lane.addRightPointValidity(builder, rightPointValidityOffset);
+  FlatbufferModule.Flatbuffer.GroundTruth.Lane.addLeftPointAnnotationStatus(builder, leftPointAnnotationStatusOffset);
+  FlatbufferModule.Flatbuffer.GroundTruth.Lane.addRightPointAnnotationStatus(builder, rightPointAnnotationStatusOffset);
+
+  const newLane = FlatbufferModule.Flatbuffer.GroundTruth.Lane.endLane(builder);
+  builder.finish(newLane);
+  const bytes = builder.asUint8Array();
+  const lenBytes = new Uint8Array(4);
+  const dv = new DataView(lenBytes.buffer);
+  dv.setUint32(0, bytes.length, true);
+
+  const outbytes = new Int8Array(lenBytes.length + bytes.length);
+  outbytes.set(lenBytes);
+  outbytes.set(bytes, lenBytes.length);
+  return outbytes;
 }

--- a/demo/radar.html
+++ b/demo/radar.html
@@ -127,6 +127,7 @@
 				  <button name="load_gaps_button" id="load_gaps_button">Load<br/>Gaps</button>
 				  <button name="load_radar_button" id="load_radar_button">Load<br/>Radar</button>
 				  <button name="download_lanes_button" id="download_lanes_button">Download<br/>Lanes</button>
+					<button name="save_lanes_button" id="save_lanes_button">Save<br/>Lanes</button>
 				  <button name="reload_lanes_button" id="reload_lanes_button">Annotate<br/>Lanes</button>
 				</div>
 			  </div>


### PR DESCRIPTION
This PR adds support for updating lanes flatbuffer files in S3 directly from potree. Currently, the `Save Lanes` button this PR adds will create a new `upload-testing-lanes.fb` file in S3 directories. These files do no have a spine and only contain the left and right polylines. 

What this PR does:
1. Adds a `Save Lanes` button
2. Prompts user if they are sure they would like to overwrite data
3. Saves updated lane data to S3.
4. Retains previous functionality of the `Download Lanes` button

We will still need to figure out how to create a new spine from the updated left and right polylines. This will be accomplished by running `convert-lanes-json-to-flatbuffer.py` from AWS.

This is attached to issue #167 




