### PR TITLE
Close the Loop: annotating lanes in potree

### DIFF
--- a/common/overlay.js
+++ b/common/overlay.js
@@ -15,7 +15,7 @@ function createLoadingBar(id) {
 
   // https://loading.io/progress/#reference
   // data-stroke-width & data-stroke-width determines the height of the bar
-  // style width determines how long the bar is  
+  // style width determines how long the bar is
   const options = {
     "data-stroke":                  loadingBarColor,
     "data-stroke-trail-background": loadingBarColor,
@@ -58,11 +58,11 @@ export function resetProgressBars(numTasks=2) {
   setLoadingScreen()
 }
 
-/* 
+/*
  * Function that hands back control of the thread to the window such that it can update the progress bar.
- * Without using it whenever setting the loading bar, the javascript code will run and block the UI that 
- * needs to update the loading bar  
- * CURRENTLY: even though everything should be 
+ * Without using it whenever setting the loading bar, the javascript code will run and block the UI that
+ * needs to update the loading bar
+ * CURRENTLY: even though everything should be
 */
 export async function pause(name) {
   // argument for debugging if user wants to log what is currently trying to set the progress bar

--- a/common/playbar.js
+++ b/common/playbar.js
@@ -451,3 +451,24 @@ async function saveLaneChangesHelper (lane, FlatbufferModule) {
   lane.leftPointAnnotationStatus = Array.from({ length: leftLength }).map(x => 1);
   lane.rightPointAnnotationStatus = Array.from({ length: rightLength }).map(x => 1);
 }
+
+function updateSpine (left, right) {
+  // <script src="https://sdk.amazonaws.com/js/aws-sdk-2.283.1.min.js"></script>
+
+  AWS.config.update({ region: 'REGION' });
+  AWS.config.credentials = new AWS.CognitoIdentityCredentials({ IdentityPoolId: 'IDENTITY_POOL_ID' });
+  var lambda = new AWS.Lambda({ region: 'REGION', apiVersion: '2015-03-31' });
+
+  const params = {
+    left: left,
+    right: right
+  };
+
+  lambda.invoke(params, function(err, data) {
+    if (err) {
+      prompt(err);
+    } else {
+      return JSON.parse(data.Payload);
+    }
+  });
+}

--- a/common/playbar.js
+++ b/common/playbar.js
@@ -394,7 +394,7 @@ function addPlaybarListeners () {
 }
 
 
-async function saveLaneChanges () {
+function saveLaneChanges () {
   const lane = {
     id: 0,
     timestamp: [],
@@ -428,7 +428,7 @@ async function saveLaneChanges () {
   }
 
   // Get New Spine Vertices
-  await updateSpine(bucket, name, lane.left, lane.right);
+  updateSpine(bucket, name, lane.left, lane.right);
 }
 
 async function updateSpine (bucket, name, left, right) {

--- a/common/playbar.js
+++ b/common/playbar.js
@@ -431,7 +431,7 @@ function saveLaneChanges () {
   updateSpine(bucket, name, lane.left, lane.right);
 }
 
-async function updateSpine (bucket, name, left, right) {
+function updateSpine (bucket, name, left, right) {
   const input = {
     bucket: bucket,
     name: name,
@@ -439,8 +439,8 @@ async function updateSpine (bucket, name, left, right) {
     right: right
   };
   const lambda = getLambda();
-  await lambda.invoke({
-    FunctionName: 'arn:aws:lambda:us-east-1:757877321035:function:UpdateLanes',
+  lambda.invoke({
+    FunctionName: 'arn:aws:lambda:us-east-1:757877321035:function:UpdateLanes:1',
     LogType: 'None',
     Payload: JSON.stringify(input)
   }, function (err, data) {

--- a/demo/loaderUtilities.js
+++ b/demo/loaderUtilities.js
@@ -120,10 +120,8 @@ export async function writeFileToS3 (s3, bucket, name, subdirectory, filename, b
       Body: buffer
     });
     request.on("httpUploadProgress", async (e) => {
-      // await updateLoadingBar(e.loaded / e.total * 100)
     });
     await request.promise();
-    // incrementLoadingBarTotal(`${filename} uploaded`)
   } catch (e) {
     console.error("Error: could not write file to S3: ", e);
   }

--- a/demo/paramLoader.js
+++ b/demo/paramLoader.js
@@ -54,6 +54,14 @@ export const s3 = bucket && region && name && accessKeyId && secretAccessKey &&
         sessionToken: sessionToken,
     });
 
+export const lambda = new AWS.Lambda({
+  region: region,
+  accessKeyId: accessKeyId,
+  secretAccessKey: secretAccessKey,
+  sessionToken: sessionToken,
+  // apiVersion: '2015-03-31'
+});
+
 if (!(s3 || window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')) {
     window.history.back()
 };
@@ -67,7 +75,7 @@ export const defaultTimeRange = {
     initial: 0
 }
 
-// returns a THREE.ShaderMaterial object that should be used as standard 
+// returns a THREE.ShaderMaterial object that should be used as standard
 export function getShaderMaterial() {
     let uniforms = {
         color: { value: new THREE.Color(0x00ff00) },

--- a/demo/paramLoader.js
+++ b/demo/paramLoader.js
@@ -59,7 +59,7 @@ export const lambda = new AWS.Lambda({
   accessKeyId: accessKeyId,
   secretAccessKey: secretAccessKey,
   sessionToken: sessionToken,
-  // apiVersion: '2015-03-31'
+  apiVersion: '2015-03-31'
 });
 
 if (!(s3 || window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')) {

--- a/demo/paramLoader.js
+++ b/demo/paramLoader.js
@@ -54,13 +54,15 @@ export const s3 = bucket && region && name && accessKeyId && secretAccessKey &&
         sessionToken: sessionToken,
     });
 
-export const lambda = new AWS.Lambda({
-  region: region,
-  accessKeyId: accessKeyId,
-  secretAccessKey: secretAccessKey,
-  sessionToken: sessionToken,
-  apiVersion: '2015-03-31'
-});
+export function getLambda () {
+  return new AWS.Lambda({
+    region: region,
+    accessKeyId: accessKeyId,
+    secretAccessKey: secretAccessKey,
+    sessionToken: sessionToken,
+    apiVersion: '2015-03-31'
+  });
+}
 
 if (!(s3 || window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')) {
     window.history.back()


### PR DESCRIPTION
This PR finishes closing the loop between potree and AWS by adding a AWS Lambda function and writing a new `lanes.fb` file directly to S3 instead of manually calling a script and uploading the new file. The script is modified and placed in a Lambda function, called by potree. There are no known bugs introduced by this PR, but versioning will need to be used for our Lambda function if we intend to make changes to it. This is a best practice. 

Location of Lambda function:
https://console.aws.amazon.com/lambda/home?region=us-east-1#/functions/UpdateLanes?tab=configuration




