### PR TITLE
Fix/issue182 extrinsics loading bug

### DIFF
--- a/demo/calibrationManager.js
+++ b/demo/calibrationManager.js
@@ -57,7 +57,7 @@ export async function loadVelo2Rtk(s3, bucket, name) {
     try {
       const response = await fetch(calFiles.objectName);
       incrementLoadingBarTotal("cals downloaded")
-      const extrinsics = parseCalibrationFile(response.text());
+      const extrinsics = parseCalibrationFile(await response.text());
       incrementLoadingBarTotal("cals loaded")
       return extrinsics;
     } catch (err) {

--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -45,7 +45,7 @@ async function loadLanes(s3, bucket, name, fname, supplierNum, annotationMode, v
     const response = await fetch(laneFiles.objectName);
     incrementLoadingBarTotal("lanes downloaded")
     const FlatbufferModule = await import(laneFiles.schemaFile);
-    const laneGeometries = await parseLanes(response.arrayBuffer(), FlatbufferModule, resolvedSupplierNum, annotationMode, volumes);
+    const laneGeometries = await parseLanes(await response.arrayBuffer(), FlatbufferModule, resolvedSupplierNum, annotationMode, volumes);
     incrementLoadingBarTotal("lanes loaded")
     return laneGeometries;
   }

--- a/demo/loaderHelper.js
+++ b/demo/loaderHelper.js
@@ -46,6 +46,17 @@ function finishLoading({pointcloud}) {
   const cloudCanUseCalibrationPanels = canUseCalibrationPanels(pointcloud.pcoGeometry.pointAttributes.attributes);
   window.canEnableCalibrationPanels = window.canEnableCalibrationPanels && cloudCanUseCalibrationPanels;
 
+  if (window.velo2RtkExtrinsicsLoaded) {
+
+    let velo2RtkOld = window.extrinsics.velo2Rtk.old;
+    let velo2RtkNew = window.extrinsics.velo2Rtk.new;
+
+    material.uniforms.velo2RtkXYZOld.value.set(velo2RtkOld.x, velo2RtkOld.y, velo2RtkOld.z);
+    material.uniforms.velo2RtkRPYOld.value.set(velo2RtkOld.roll, velo2RtkOld.pitch, velo2RtkOld.yaw);
+    material.uniforms.velo2RtkXYZNew.value.set(velo2RtkNew.x, velo2RtkNew.y, velo2RtkNew.z);
+    material.uniforms.velo2RtkRPYNew.value.set(velo2RtkNew.roll, velo2RtkNew.pitch, velo2RtkNew.yaw);
+  }
+
   if (window.canEnableCalibrationPanels) {
     enablePanels();
 
@@ -117,16 +128,7 @@ async function loadDataIntoDocument() {
 		    console.log("Velo2Rtk Extrinsics Loaded!");
 		    window.extrinsics.velo2Rtk = { old: velo2Rtk, new: velo2Rtk };
 		    storeVelo2Rtk(window.extrinsics.velo2Rtk.new);
-		    for (const cloud of viewer.scene.pointclouds) {
-
-		      let velo2RtkOld = window.extrinsics.velo2Rtk.old;
-		      let velo2RtkNew = window.extrinsics.velo2Rtk.new;
-
-		      cloud.material.uniforms.velo2RtkXYZOld.value.set(velo2RtkOld.x, velo2RtkOld.y, velo2RtkOld.z);
-		      cloud.material.uniforms.velo2RtkRPYOld.value.set(velo2RtkOld.roll, velo2RtkOld.pitch, velo2RtkOld.yaw);
-		      cloud.material.uniforms.velo2RtkXYZNew.value.set(velo2RtkNew.x, velo2RtkNew.y, velo2RtkNew.z);
-		      cloud.material.uniforms.velo2RtkRPYNew.value.set(velo2RtkNew.roll, velo2RtkNew.pitch, velo2RtkNew.yaw);
-		    }
+		    window.velo2RtkExtrinsicsLoaded = true;
                   } else {
 		    disablePanels("Unable to load extrinsics file");
                   }

--- a/demo/rtkLoader.js
+++ b/demo/rtkLoader.js
@@ -48,7 +48,7 @@ async function loadRtk(s3, bucket, name) {
     const response = await fetch(rtkFiles.objectName);
     incrementLoadingBarTotal("rtk downloaded")
     const FlatbufferModule = await import(rtkFiles.schemaFile);
-    const result = await parseRTK(response.arrayBuffer(), FlatbufferModule);
+    const result = await parseRTK(await response.arrayBuffer(), FlatbufferModule);
     incrementLoadingBarTotal("rtk loaded")
     return result;
   }


### PR DESCRIPTION
This PR adds a fix that ensures that the extrinsics and calibration panel values are properly passed to shader when application first loads up. Also adds a few minor fixes for viewing local data. See #182 





