### PR TITLE
Update Lambda to version 2

### DIFF
--- a/common/playbar.js
+++ b/common/playbar.js
@@ -440,7 +440,7 @@ function updateSpine (bucket, name, left, right) {
   };
   const lambda = getLambda();
   lambda.invoke({
-    FunctionName: 'arn:aws:lambda:us-east-1:757877321035:function:UpdateLanes:1',
+    FunctionName: 'arn:aws:lambda:us-east-1:757877321035:function:UpdateLanes:2',
     LogType: 'None',
     Payload: JSON.stringify(input)
   }, function (err, data) {


### PR DESCRIPTION
This updates the version of the AWS Lambda function used in potree to version 2. Version 2 copies a backup lanes.fb file if one doesn't exist so that we don't end up overwriting the original lanes files.



