### PR TITLE
Fix control point loading errors and remove hard coded control point values

### DIFF
--- a/demo/controlPointLoader.js
+++ b/demo/controlPointLoader.js
@@ -182,35 +182,8 @@ function getControlPointColor (controlPointType) {
   // return controlPointColorsTable[controlPointType]
 }
 
-// const controlPointColorsTable = {
-//   'control_point_3_rtk_relative.fb': new THREE.Color(0x00ffff),
-//
-//   'viz_Spheres3D_LaneSense_cp1_0.7s_left.fb': new THREE.Color(0xffff00),
-//   'viz_Spheres3D_LaneSense_cp2_1.0s_left.fb': new THREE.Color(0xffff00),
-//   'viz_Spheres3D_LaneSense_cp3_1.3s_left.fb': new THREE.Color(0xffff00),
-//   'viz_Spheres3D_LaneSense_cp4_2.0s_left.fb': new THREE.Color(0xffff00),
-//
-//   'viz_Spheres3D_LaneSense_cp1_0.7s_right.fb': new THREE.Color(0x0000ff),
-//   'viz_Spheres3D_LaneSense_cp2_1.0s_right.fb': new THREE.Color(0x0000ff),
-//   'viz_Spheres3D_LaneSense_cp3_1.3s_right.fb': new THREE.Color(0x0000ff),
-//   'viz_Spheres3D_LaneSense_cp4_2.0s_right.fb': new THREE.Color(0x0000ff),
-//
-//   'viz_Spheres3D_SPP_cp1_5.0m_spp.fb' : new THREE.Color(0xff0000),
-//   'viz_Spheres3D_SPP_cp2_10.0m_spp.fb' : new THREE.Color(0xff0000),
-//   'viz_Spheres3D_SPP_cp3_15.0m_spp.fb' : new THREE.Color(0xff0000),
-//   'viz_Spheres3D_SPP_cp4_20.0m_spp.fb' : new THREE.Color(0xff0000),
-//   'viz_Spheres3D_SPP_cp5_25.0m_spp.fb' : new THREE.Color(0xff0000),
-//   'viz_Spheres3D_SPP_cp6_30.0m_spp.fb' : new THREE.Color(0xff0000),
-//   'viz_Spheres3D_SPP_cp7_35.0m_spp.fb' : new THREE.Color(0xff0000),
-//   'viz_Spheres3D_SPP_cp8_40.0m_spp.fb' : new THREE.Color(0xff0000),
-//   'viz_Spheres3D_SPP_cp9_45.0m_spp.fb' : new THREE.Color(0xff0000),
-//   'viz_Spheres3D_SPP_cp10_50.0m_spp.fb' : new THREE.Color(0xff0000)
-// };
-// const getControlPointColor = (controlPointType) => controlPointColorsTable[controlPointType];
-
 const controlPointNamesTable = {
   'control_point_3_rtk_relative.fb': 'REM Control Points',
-
   'viz_Spheres3D_LaneSense_cp1_0.7s_left.fb': '0.7s Left Control Points',
   'viz_Spheres3D_LaneSense_cp2_1.0s_left.fb': '1.0s Left Control Points',
   'viz_Spheres3D_LaneSense_cp3_1.3s_left.fb': '1.3s Left Control Points',
@@ -220,16 +193,16 @@ const controlPointNamesTable = {
   'viz_Spheres3D_LaneSense_cp3_1.3s_right.fb': '1.3s Right Control Points',
   'viz_Spheres3D_LaneSense_cp4_2.0s_right.fb': '2.0s Right Control Points',
 
-  'viz_Spheres3D_SPP_cp1_5.0m_spp.fb' : '5m SPP Control Points',
-  'viz_Spheres3D_SPP_cp2_10.0m_spp.fb' : '10m SPP Control Points',
-  'viz_Spheres3D_SPP_cp3_15.0m_spp.fb' : '15m SPP Control Points',
-  'viz_Spheres3D_SPP_cp4_20.0m_spp.fb' : '20m SPP Control Points',
-  'viz_Spheres3D_SPP_cp5_25.0m_spp.fb' : '25m SPP Control Points',
-  'viz_Spheres3D_SPP_cp6_30.0m_spp.fb' : '30m SPP Control Points',
-  'viz_Spheres3D_SPP_cp7_35.0m_spp.fb' : '35m SPP Control Points',
-  'viz_Spheres3D_SPP_cp8_40.0m_spp.fb' : '40m SPP Control Points',
-  'viz_Spheres3D_SPP_cp9_45.0m_spp.fb' : '45m SPP Control Points',
-  'viz_Spheres3D_SPP_cp10_50.0m_spp.fb' : '50m SPP Control Points'
+  // 'viz_Spheres3D_SPP_cp1_5.0m_spp.fb' : '5m SPP Control Points',
+  // 'viz_Spheres3D_SPP_cp2_10.0m_spp.fb' : '10m SPP Control Points',
+  // 'viz_Spheres3D_SPP_cp3_15.0m_spp.fb' : '15m SPP Control Points',
+  // 'viz_Spheres3D_SPP_cp4_20.0m_spp.fb' : '20m SPP Control Points',
+  // 'viz_Spheres3D_SPP_cp5_25.0m_spp.fb' : '25m SPP Control Points',
+  // 'viz_Spheres3D_SPP_cp6_30.0m_spp.fb' : '30m SPP Control Points',
+  // 'viz_Spheres3D_SPP_cp7_35.0m_spp.fb' : '35m SPP Control Points',
+  // 'viz_Spheres3D_SPP_cp8_40.0m_spp.fb' : '40m SPP Control Points',
+  // 'viz_Spheres3D_SPP_cp9_45.0m_spp.fb' : '45m SPP Control Points',
+  // 'viz_Spheres3D_SPP_cp10_50.0m_spp.fb' : '50m SPP Control Points'
 };
 
 function getControlPointName (controlPointType) {

--- a/demo/controlPointLoader.js
+++ b/demo/controlPointLoader.js
@@ -3,18 +3,16 @@ import { getShaderMaterial } from '../demo/paramLoader.js';
 import { updateLoadingBar, incrementLoadingBarTotal } from '../common/overlay.js';
 
 // load control points
-export async function loadControlPointsCallback (s3, bucket, name, animationEngine, s3Files = null) {
+export async function loadControlPointsCallback (s3, bucket, name, animationEngine, files) {
   // Handle local files
-  if (!s3Files) {
-    await loadControlPointsCallbackHelper(s3, bucket, name, animationEngine);
-  } else {
+  if (files) {
     // Handle s3 files
-    for (let s3File of s3Files) {
-      s3File = s3File.split(/.*[\/|\\]/)[1];
-      if (!s3File.endsWith('cp.fb')) {
-        continue;
-      } else {
-        await loadControlPointsCallbackHelper(s3, bucket, name, animationEngine, s3File);
+    for (let file of files) {
+      // Remove prefix filepath
+      file = file.split(/.*[\/|\\]/)[1];
+      // Handle old naming and new naming schemas
+      if (file.includes('rtk_relative') || file.includes('viz_Spheres3D_')) {
+        await loadControlPointsCallbackHelper(s3, bucket, name, animationEngine, file);
       }
     }
   }
@@ -172,14 +170,8 @@ function getControlPointColor (controlPointType) {
     return new THREE.Color(0xffff00);
   } else if (controlPointType.includes("right")) {
     return new THREE.Color(0x0000ff);
-  // } else if (controlPointType.includes("left")) {
-  //   return new THREE.Color(0xffff00);
-  // } else if (controlPointType.includes("right")) {
-  //   return new THREE.Color(0x0000ff);
-  } else {
-    return new THREE.Color(0x0000ff);
   }
-  // return controlPointColorsTable[controlPointType]
+  return new THREE.Color(0x0000ff);
 }
 
 const controlPointNamesTable = {
@@ -192,26 +184,29 @@ const controlPointNamesTable = {
   'viz_Spheres3D_LaneSense_cp2_1.0s_right.fb': '1.0s Right Control Points',
   'viz_Spheres3D_LaneSense_cp3_1.3s_right.fb': '1.3s Right Control Points',
   'viz_Spheres3D_LaneSense_cp4_2.0s_right.fb': '2.0s Right Control Points',
-
-  // 'viz_Spheres3D_SPP_cp1_5.0m_spp.fb' : '5m SPP Control Points',
-  // 'viz_Spheres3D_SPP_cp2_10.0m_spp.fb' : '10m SPP Control Points',
-  // 'viz_Spheres3D_SPP_cp3_15.0m_spp.fb' : '15m SPP Control Points',
-  // 'viz_Spheres3D_SPP_cp4_20.0m_spp.fb' : '20m SPP Control Points',
-  // 'viz_Spheres3D_SPP_cp5_25.0m_spp.fb' : '25m SPP Control Points',
-  // 'viz_Spheres3D_SPP_cp6_30.0m_spp.fb' : '30m SPP Control Points',
-  // 'viz_Spheres3D_SPP_cp7_35.0m_spp.fb' : '35m SPP Control Points',
-  // 'viz_Spheres3D_SPP_cp8_40.0m_spp.fb' : '40m SPP Control Points',
-  // 'viz_Spheres3D_SPP_cp9_45.0m_spp.fb' : '45m SPP Control Points',
-  // 'viz_Spheres3D_SPP_cp10_50.0m_spp.fb' : '50m SPP Control Points'
+  'viz_Spheres3D_SPP_cp1_5.0m_spp.fb': '5m SPP Control Points',
+  'viz_Spheres3D_SPP_cp2_10.0m_spp.fb': '10m SPP Control Points',
+  'viz_Spheres3D_SPP_cp3_15.0m_spp.fb': '15m SPP Control Points',
+  'viz_Spheres3D_SPP_cp4_20.0m_spp.fb': '20m SPP Control Points',
+  'viz_Spheres3D_SPP_cp5_25.0m_spp.fb': '25m SPP Control Points',
+  'viz_Spheres3D_SPP_cp6_30.0m_spp.fb': '30m SPP Control Points',
+  'viz_Spheres3D_SPP_cp7_35.0m_spp.fb': '35m SPP Control Points',
+  'viz_Spheres3D_SPP_cp8_40.0m_spp.fb': '40m SPP Control Points',
+  'viz_Spheres3D_SPP_cp9_45.0m_spp.fb': '45m SPP Control Points',
+  'viz_Spheres3D_SPP_cp10_50.0m_spp.fb': '50m SPP Control Points'
 };
 
 function getControlPointName (controlPointType) {
-  if (controlPointType.includes('viz_Spheres3D_LanseSense')) {
+  if (controlPointType.includes('viz_Spheres3D_')) {
     return controlPointNamesTable[controlPointType];
   } else if (controlPointType.includes("rtk_relative")) {
     return controlPointNamesTable[controlPointType];
   }
-  let words = controlPointType.substring(13);
+  // slice off file extension
+  let words = controlPointType.slice(0, -3);
+  // remove 'viz_Spheres3D_' prefix
+  words = words.substring(13);
+  // split on '_', join into display name
   words = words.split("_");
   words = words.join(" ");
   return words;

--- a/demo/controlPointLoader.js
+++ b/demo/controlPointLoader.js
@@ -3,7 +3,24 @@ import { getShaderMaterial } from '../demo/paramLoader.js';
 import { updateLoadingBar, incrementLoadingBarTotal } from '../common/overlay.js';
 
 // load control points
-export async function loadControlPointsCallback (s3, bucket, name, animationEngine, controlPointType) {
+export async function loadControlPointsCallback (s3, bucket, name, animationEngine, s3Files = null) {
+  // Handle local files
+  if (!s3Files) {
+    await loadControlPointsCallbackHelper(s3, bucket, name, animationEngine);
+  } else {
+    // Handle s3 files
+    for (let s3File of s3Files) {
+      s3File = s3File.split(/.*[\/|\\]/)[1];
+      if (!s3File.endsWith('cp.fb')) {
+        continue;
+      } else {
+        await loadControlPointsCallbackHelper(s3, bucket, name, animationEngine, s3File);
+      }
+    }
+  }
+}
+
+async function loadControlPointsCallbackHelper (s3, bucket, name, animationEngine, controlPointType) {
   const shaderMaterial = getShaderMaterial();
   const controlPointShaderMaterial = shaderMaterial.clone();
   await loadControlPoints(s3, bucket, name, controlPointShaderMaterial, animationEngine, (sphereMeshes) => {
@@ -148,31 +165,48 @@ async function createControlMeshes (controlPoints, controlPointShaderMaterial, F
   return allSpheres;
 }
 
-const controlPointColorsTable = {
-  'control_point_3_rtk_relative.fb': new THREE.Color(0x00ffff),
+function getControlPointColor (controlPointType) {
+  if (controlPointType.includes("rtk")) {
+    return new THREE.Color(0x00ffff);
+  } else if (controlPointType.includes("left")) {
+    return new THREE.Color(0xffff00);
+  } else if (controlPointType.includes("right")) {
+    return new THREE.Color(0x0000ff);
+  // } else if (controlPointType.includes("left")) {
+  //   return new THREE.Color(0xffff00);
+  // } else if (controlPointType.includes("right")) {
+  //   return new THREE.Color(0x0000ff);
+  } else {
+    return new THREE.Color(0x0000ff);
+  }
+  // return controlPointColorsTable[controlPointType]
+}
 
-  'viz_Spheres3D_LaneSense_cp1_0.7s_left.fb': new THREE.Color(0xffff00),
-  'viz_Spheres3D_LaneSense_cp2_1.0s_left.fb': new THREE.Color(0xffff00),
-  'viz_Spheres3D_LaneSense_cp3_1.3s_left.fb': new THREE.Color(0xffff00),
-  'viz_Spheres3D_LaneSense_cp4_2.0s_left.fb': new THREE.Color(0xffff00),
-
-  'viz_Spheres3D_LaneSense_cp1_0.7s_right.fb': new THREE.Color(0x0000ff),
-  'viz_Spheres3D_LaneSense_cp2_1.0s_right.fb': new THREE.Color(0x0000ff),
-  'viz_Spheres3D_LaneSense_cp3_1.3s_right.fb': new THREE.Color(0x0000ff),
-  'viz_Spheres3D_LaneSense_cp4_2.0s_right.fb': new THREE.Color(0x0000ff),
-
-  'viz_Spheres3D_SPP_cp1_5.0m_spp.fb' : new THREE.Color(0xff0000),
-  'viz_Spheres3D_SPP_cp2_10.0m_spp.fb' : new THREE.Color(0xff0000),
-  'viz_Spheres3D_SPP_cp3_15.0m_spp.fb' : new THREE.Color(0xff0000),
-  'viz_Spheres3D_SPP_cp4_20.0m_spp.fb' : new THREE.Color(0xff0000),
-  'viz_Spheres3D_SPP_cp5_25.0m_spp.fb' : new THREE.Color(0xff0000),
-  'viz_Spheres3D_SPP_cp6_30.0m_spp.fb' : new THREE.Color(0xff0000),
-  'viz_Spheres3D_SPP_cp7_35.0m_spp.fb' : new THREE.Color(0xff0000),
-  'viz_Spheres3D_SPP_cp8_40.0m_spp.fb' : new THREE.Color(0xff0000),
-  'viz_Spheres3D_SPP_cp9_45.0m_spp.fb' : new THREE.Color(0xff0000),
-  'viz_Spheres3D_SPP_cp10_50.0m_spp.fb' : new THREE.Color(0xff0000)
-};
-const getControlPointColor = (controlPointType) => controlPointColorsTable[controlPointType];
+// const controlPointColorsTable = {
+//   'control_point_3_rtk_relative.fb': new THREE.Color(0x00ffff),
+//
+//   'viz_Spheres3D_LaneSense_cp1_0.7s_left.fb': new THREE.Color(0xffff00),
+//   'viz_Spheres3D_LaneSense_cp2_1.0s_left.fb': new THREE.Color(0xffff00),
+//   'viz_Spheres3D_LaneSense_cp3_1.3s_left.fb': new THREE.Color(0xffff00),
+//   'viz_Spheres3D_LaneSense_cp4_2.0s_left.fb': new THREE.Color(0xffff00),
+//
+//   'viz_Spheres3D_LaneSense_cp1_0.7s_right.fb': new THREE.Color(0x0000ff),
+//   'viz_Spheres3D_LaneSense_cp2_1.0s_right.fb': new THREE.Color(0x0000ff),
+//   'viz_Spheres3D_LaneSense_cp3_1.3s_right.fb': new THREE.Color(0x0000ff),
+//   'viz_Spheres3D_LaneSense_cp4_2.0s_right.fb': new THREE.Color(0x0000ff),
+//
+//   'viz_Spheres3D_SPP_cp1_5.0m_spp.fb' : new THREE.Color(0xff0000),
+//   'viz_Spheres3D_SPP_cp2_10.0m_spp.fb' : new THREE.Color(0xff0000),
+//   'viz_Spheres3D_SPP_cp3_15.0m_spp.fb' : new THREE.Color(0xff0000),
+//   'viz_Spheres3D_SPP_cp4_20.0m_spp.fb' : new THREE.Color(0xff0000),
+//   'viz_Spheres3D_SPP_cp5_25.0m_spp.fb' : new THREE.Color(0xff0000),
+//   'viz_Spheres3D_SPP_cp6_30.0m_spp.fb' : new THREE.Color(0xff0000),
+//   'viz_Spheres3D_SPP_cp7_35.0m_spp.fb' : new THREE.Color(0xff0000),
+//   'viz_Spheres3D_SPP_cp8_40.0m_spp.fb' : new THREE.Color(0xff0000),
+//   'viz_Spheres3D_SPP_cp9_45.0m_spp.fb' : new THREE.Color(0xff0000),
+//   'viz_Spheres3D_SPP_cp10_50.0m_spp.fb' : new THREE.Color(0xff0000)
+// };
+// const getControlPointColor = (controlPointType) => controlPointColorsTable[controlPointType];
 
 const controlPointNamesTable = {
   'control_point_3_rtk_relative.fb': 'REM Control Points',
@@ -197,4 +231,15 @@ const controlPointNamesTable = {
   'viz_Spheres3D_SPP_cp9_45.0m_spp.fb' : '45m SPP Control Points',
   'viz_Spheres3D_SPP_cp10_50.0m_spp.fb' : '50m SPP Control Points'
 };
-const getControlPointName = (controlPointType) => controlPointNamesTable[controlPointType];
+
+function getControlPointName (controlPointType) {
+  if (controlPointType.includes('viz_Spheres3D_LanseSense')) {
+    return controlPointNamesTable[controlPointType];
+  } else if (controlPointType.includes("rtk_relative")) {
+    return controlPointNamesTable[controlPointType];
+  }
+  let words = controlPointType.substring(13);
+  words = words.split("_");
+  words = words.join(" ");
+  return words;
+}

--- a/demo/loaderHelper.js
+++ b/demo/loaderHelper.js
@@ -88,9 +88,13 @@ export async function loadPotree() {
   // now that animation engine has been created, can add event listeners
   createPlaybar();
 
+  // get files from s3
   const filesArray = await getS3Files(s3, bucket, name)
   const datasetFiles = filesArray[0];
-  const s3FilesTable = filesArray[1];
+  const filesTable = filesArray[1];
+
+  // TODO get local files
+
   const numTasks = await determineNumTasks(datasetFiles)
   setNumTasks(numTasks)
 
@@ -105,7 +109,7 @@ export async function loadPotree() {
   addCalibrationButton();
   addDetectionButton();
   // load in actual data & configure playbar along the way
-  await loadDataIntoDocument();
+  await loadDataIntoDocument(filesTable);
 
   // Load Pointclouds
   if (runLocalPointCloud) {
@@ -120,7 +124,7 @@ export async function loadPotree() {
 }
 
 // loads all necessary data (car obj/texture, rtk, radar, tracks, etc...)
-async function loadDataIntoDocument() {
+async function loadDataIntoDocument(filesTable) {
 	        // Load Data Sources in loadRtkCallback:
                 await loadRtkCallback(s3, bucket, name, async () => {
 		// Load Extrinsics:
@@ -176,49 +180,12 @@ async function loadDataIntoDocument() {
 			console.error("Could not load Tracks: ", e);
 		}
 
-
-
+    // Load Control Points (REM, LaneSense, SPP)
 		try {
-			loadControlPointsCallback(s3, bucket, name, animationEngine, s3FilesTable['3_Assessments']);
+			loadControlPointsCallback(s3, bucket, name, animationEngine, filesTable['3_Assessments']);
 		} catch (e) {
 			console.error("No control points: ", e);
 		}
-
-		// try {
-		// 	loadRemCallback(s3, bucket, name, animationEngine);
-		// } catch (e) {
-		// 	console.error("No rem points: ", e);
-		// }
-
-		// try {
-		// 	// LaneSense
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp1_0.7s_left.fb');
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp1_0.7s_right.fb');
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp2_1.0s_left.fb');
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp2_1.0s_right.fb');
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp3_1.3s_left.fb');
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp3_1.3s_right.fb');
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp4_2.0s_left.fb');
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp4_2.0s_right.fb');
-		// } catch (e) {
-		// 	console.error("Missing LaneSense sample points: ", e);
-		// }
-		//
-		// try {
-		// 	// SPP
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp1_5.0m_spp.fb');
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp2_10.0m_spp.fb');
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp3_15.0m_spp.fb');
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp4_20.0m_spp.fb');
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp5_25.0m_spp.fb');
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp6_30.0m_spp.fb');
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp7_35.0m_spp.fb');
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp8_40.0m_spp.fb');
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp9_45.0m_spp.fb');
-		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp10_50.0m_spp.fb');
-		// } catch (e) {
-		// 	console.error("Missing SPP sample points: ", e);
-		// }
 
 		// Load Radar:
 		try {

--- a/demo/loaderHelper.js
+++ b/demo/loaderHelper.js
@@ -22,6 +22,7 @@ import { addDetectionButton, detectionDownloads } from "../demo/detectionLoader.
 import { PointAttributeNames } from "../src/loader/PointAttributes.js";
 import { setNumTasks } from "../common/overlay.js"
 import { loadControlPointsCallback } from "../demo/controlPointLoader.js"
+import { getS3Files } from "../demo/loaderUtilities.js"
 
 
 function canUseCalibrationPanels(attributes) {
@@ -87,7 +88,9 @@ export async function loadPotree() {
   // now that animation engine has been created, can add event listeners
   createPlaybar();
 
-  const datasetFiles = await getS3Files()
+  const filesArray = await getS3Files(s3, bucket, name)
+  const datasetFiles = filesArray[0];
+  const s3FilesTable = filesArray[1];
   const numTasks = await determineNumTasks(datasetFiles)
   setNumTasks(numTasks)
 
@@ -173,47 +176,49 @@ async function loadDataIntoDocument() {
 			console.error("Could not load Tracks: ", e);
 		}
 
+
+
+		try {
+			loadControlPointsCallback(s3, bucket, name, animationEngine, s3FilesTable['3_Assessments']);
+		} catch (e) {
+			console.error("No control points: ", e);
+		}
+
 		// try {
 		// 	loadRemCallback(s3, bucket, name, animationEngine);
 		// } catch (e) {
 		// 	console.error("No rem points: ", e);
 		// }
 
-		try {
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'control_point_3_rtk_relative.fb');
-		} catch (e) {
-			console.error("No rem points: ", e);
-		}
-
-		try {
-			// LaneSense
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp1_0.7s_left.fb');
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp1_0.7s_right.fb');
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp2_1.0s_left.fb');
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp2_1.0s_right.fb');
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp3_1.3s_left.fb');
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp3_1.3s_right.fb');
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp4_2.0s_left.fb');
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp4_2.0s_right.fb');
-		} catch (e) {
-			console.error("Missing LaneSense sample points: ", e);
-		}
-
-		try {
-			// SPP
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp1_5.0m_spp.fb');
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp2_10.0m_spp.fb');
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp3_15.0m_spp.fb');
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp4_20.0m_spp.fb');
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp5_25.0m_spp.fb');
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp6_30.0m_spp.fb');
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp7_35.0m_spp.fb');
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp8_40.0m_spp.fb');
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp9_45.0m_spp.fb');
-			loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp10_50.0m_spp.fb');
-		} catch (e) {
-			console.error("Missing SPP sample points: ", e);
-		}
+		// try {
+		// 	// LaneSense
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp1_0.7s_left.fb');
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp1_0.7s_right.fb');
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp2_1.0s_left.fb');
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp2_1.0s_right.fb');
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp3_1.3s_left.fb');
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp3_1.3s_right.fb');
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp4_2.0s_left.fb');
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_LaneSense_cp4_2.0s_right.fb');
+		// } catch (e) {
+		// 	console.error("Missing LaneSense sample points: ", e);
+		// }
+		//
+		// try {
+		// 	// SPP
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp1_5.0m_spp.fb');
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp2_10.0m_spp.fb');
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp3_15.0m_spp.fb');
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp4_20.0m_spp.fb');
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp5_25.0m_spp.fb');
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp6_30.0m_spp.fb');
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp7_35.0m_spp.fb');
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp8_40.0m_spp.fb');
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp9_45.0m_spp.fb');
+		// 	loadControlPointsCallback(s3, bucket, name, animationEngine, 'viz_Spheres3D_SPP_cp10_50.0m_spp.fb');
+		// } catch (e) {
+		// 	console.error("Missing SPP sample points: ", e);
+		// }
 
 		// Load Radar:
 		try {
@@ -235,45 +240,6 @@ async function loadDataIntoDocument() {
 		// animationEngine.configure(tstart, tend, playbackRate);
 		// animationEngine.launch();
 	}); // END loadRtkCallback()
-}
-
-/**
- * @brief Gets list of "all" files located in s3 for the dataset
- * @note Have to do a request for each sub dir as there is a limit on # objects that can be requested
- * (1_Viz has >1000 raw .bin that take up all the space so do multiple requests -- not all 1_Viz's .bin are included)
- * @returns {Promise<Array<String> | null>} List of files located within s3 for the dataset (null if running local point cloud)
- */
-async function getS3Files() {
-	if (bucket == null) return null // local point cloud
-	const removePrefix = (str) => str.split(name+'/')[1]
-
-	const topLevel = await s3.listObjectsV2({
-		Bucket: bucket,
-		Delimiter: "/",
-		Prefix: `${name}/`
-	}).promise()
-
-	const topLevelDirs = topLevel.CommonPrefixes
-		.map(listing => listing.Prefix)
-		.filter(str => {
-			const noPrefix = removePrefix(str)
-			const delimIdx = noPrefix.indexOf("/")
-			// -1 if no other '/' found, meaning is a file & not a directory
-			return delimIdx != -1
-		})
-
-	// consolidate each subdirs' contents after doing multiple requests
-	// prevent one folder's numerous binary files from blocking the retrieval of other dirs' files
-	const filePaths = []
-	for (const dir of topLevelDirs) {
-		const listData = await s3.listObjectsV2({
-			Bucket: bucket,
-			Prefix: dir,
-		}).promise()
-		listData.Contents.forEach(fileListing => filePaths.push(fileListing.Key))
-	}
-
-	return filePaths
 }
 
 /**

--- a/demo/loaderUtilities.js
+++ b/demo/loaderUtilities.js
@@ -215,6 +215,8 @@ export async function getS3Files (s3, bucket, name) {
   const filePaths = [];
   const table = {};
   for (const dir of topLevelDirs) {
+    // Exclude '1_Viz' directory
+    if (dir.includes('1_Viz/')) continue;
     const list = [];
     const listData = await s3.listObjectsV2({
       Bucket: bucket,


### PR DESCRIPTION
This PR fixes a few errors related to the way control points were loaded before. It utilizes a function for reading files from S3 to potree and creates a table to keep data organized. However, there is more work to be done with file loading within these functions (right now we need two data structures to load files from and to count files. This should be fixed in another PR). This PR only handles control point loading. It allows us to upload an arbitrary number of control points to S3 and then display them appropriately in potree. Before, if we did this, potree would crash. Now we have something in place to handle that!


