### PR TITLE
Load multiple track files

### DIFF
--- a/demo/loaderHelper.js
+++ b/demo/loaderHelper.js
@@ -77,7 +77,7 @@ function finishLoading({pointcloud}) {
   } else {
   	if (!cloudCanUseCalibrationPanels) {
     	window.disableReason = "Pointcloud was not serialized with the necessary point attributes"
-    } 
+    }
   	disablePanels(window.disableReason);
   }
 }
@@ -193,9 +193,9 @@ async function loadDataIntoDocument(filesTable) {
 		// Load Tracks:
 		try {
 			// TODO shaderMaterial
-			let shaderMaterial = getShaderMaterial();
-			let trackShaderMaterial = shaderMaterial.clone();
-			loadTracksCallback(s3, bucket, name, trackShaderMaterial, animationEngine);
+			const shaderMaterial = getShaderMaterial();
+			const trackShaderMaterial = shaderMaterial.clone();
+			loadTracksCallback(s3, bucket, name, trackShaderMaterial, animationEngine, filesTable['2_Truth']);
 		} catch (e) {
 			console.error("Could not load Tracks: ", e);
 		}

--- a/demo/loaderUtilities.js
+++ b/demo/loaderUtilities.js
@@ -229,3 +229,7 @@ export async function getS3Files (s3, bucket, name) {
   }
   return [filePaths, table];
 }
+
+export function removeFileExtension (filename) {
+  return filename.split('.').slice(0, -1).join('.');
+}

--- a/demo/trackLoader.js
+++ b/demo/trackLoader.js
@@ -2,7 +2,7 @@
 // import { Flatbuffer } from "../schemas/GroundTruth_generated.js";
 // import { Flatbuffer } from "http://localhost:1234/schemas/GroundTruth_generated.js";
 import { updateLoadingBar, incrementLoadingBarTotal } from "../common/overlay.js";
-import { getFbFileInfo } from "./loaderUtilities.js";
+import { getFbFileInfo, removeFileExtension } from "./loaderUtilities.js";
 
 
 // sets local variable and returns so # files can be counted
@@ -330,7 +330,9 @@ export async function loadTracksCallback(s3, bucket, name, trackShaderMaterial, 
       } else if (file === 'tracks.fb') {
         loadTracksCallbackHelper(s3, bucket, name, trackShaderMaterial, animationEngine, file, 'Tracked Objects');
       } else {
-        loadTracksCallbackHelper(s3, bucket, name, trackShaderMaterial, animationEngine, file, getTrackDisplayName(file));
+        const newTrackShaderMaterial = trackShaderMaterial.clone();
+        newTrackShaderMaterial.uniforms.color.value = new THREE.Color(0xdf00fe);
+        loadTracksCallbackHelper(s3, bucket, name, newTrackShaderMaterial, animationEngine, file, removeFileExtension(file));
       }
     }
   } else {
@@ -361,7 +363,3 @@ async function loadTracksCallbackHelper (s3, bucket, name, trackShaderMaterial, 
 		});
 	});
 }  // end of loadTracksCallback
-
-function getTrackDisplayName (filename) {
-  return filename.split('.').slice(0, -1).join('.');
-}

--- a/demo/trackLoader.js
+++ b/demo/trackLoader.js
@@ -16,11 +16,15 @@ export const trackDownloads = async (datasetFiles) => {
   return trackFiles;
 }
 
-export async function loadTracks(s3, bucket, name, shaderMaterial, animationEngine, callback) {
+export async function loadTracks(s3, bucket, name, trackFileName, shaderMaterial, animationEngine, callback) {
   const tstart = performance.now();
   if (!trackFiles) {
     console.log("No track files present")
     return
+  }
+
+  if (trackFileName) {
+    trackFiles.objectName = `${name}/2_Truth/${trackFileName}`;
   }
 
   if (s3 && bucket && name) {
@@ -316,18 +320,34 @@ async function createTrackGeometries(shaderMaterial, tracks, animationEngine) {
   return output;
 }
 
-export async function loadTracksCallback(s3, bucket, name, trackShaderMaterial, animationEngine) {
+export async function loadTracksCallback(s3, bucket, name, trackShaderMaterial, animationEngine, files) {
 
+  if (files) {
+    for (let file of files) {
+      file = file.split(/.*[\/|\\]/)[1];
+      if (!file.endsWith('tracks.fb')) {
+        continue;
+      } else if (file === 'tracks.fb') {
+        loadTracksCallbackHelper(s3, bucket, name, trackShaderMaterial, animationEngine, file, 'Tracked Objects');
+      } else {
+        loadTracksCallbackHelper(s3, bucket, name, trackShaderMaterial, animationEngine, file, getTrackDisplayName(file));
+      }
+    }
+  } else {
+    loadTracksCallbackHelper(s3, bucket, name, trackShaderMaterial, animationEngine, 'tracks.fb', 'Tracked Objects');
+  }
+}
+
+async function loadTracksCallbackHelper (s3, bucket, name, trackShaderMaterial, animationEngine, trackFileName, trackName) {
 	await loadTracks(s3, bucket, name, trackShaderMaterial, animationEngine, (trackGeometries) => {
-		let trackLayer = new THREE.Group();
-		trackLayer.name = "Tracked Objects";
+		const trackLayer = new THREE.Group();
+		trackLayer.name = trackName;
 		for (let ii = 0, len = trackGeometries.bbox.length; ii < len; ii++) {
 			trackLayer.add(trackGeometries.bbox[ii]);
 			// viewer.scene.scene.add(trackGeometries.bbox[ii]); // Original
 		}
-
 		viewer.scene.scene.add(trackLayer);
-		let e = new CustomEvent("truth_layer_added", { detail: trackLayer, writable: true });
+		const e = new CustomEvent("truth_layer_added", { detail: trackLayer, writable: true });
 		viewer.scene.dispatchEvent({
 			"type": "truth_layer_added",
 			"truthLayer": trackLayer
@@ -335,9 +355,13 @@ export async function loadTracksCallback(s3, bucket, name, trackShaderMaterial, 
 
 		// TODO check if group works as expected, then trigger "truth_layer_added" event
 		animationEngine.tweenTargets.push((gpsTime) => {
-			let currentTime = gpsTime - animationEngine.tstart;
+			const currentTime = gpsTime - animationEngine.tstart;
 			trackShaderMaterial.uniforms.minGpsTime.value = currentTime + animationEngine.activeWindow.backward;
 			trackShaderMaterial.uniforms.maxGpsTime.value = currentTime + animationEngine.activeWindow.forward;
 		});
 	});
 }  // end of loadTracksCallback
+
+function getTrackDisplayName (filename) {
+  return filename.split('.').slice(0, -1).join('.');
+}

--- a/demo/trackLoader.js
+++ b/demo/trackLoader.js
@@ -26,7 +26,8 @@ export async function loadTracks(s3, bucket, name, trackFileName, shaderMaterial
   if (trackFileName) {
     trackFiles.objectName = `${name}/2_Truth/${trackFileName}`;
   }
-
+  console.log("tracks", trackFileName);
+  console.log("tracks load", trackFiles.objectName);
   if (s3 && bucket && name) {
     (async () => {
       const schemaUrl = s3.getSignedUrl('getObject', {
@@ -321,7 +322,6 @@ async function createTrackGeometries(shaderMaterial, tracks, animationEngine) {
 }
 
 export async function loadTracksCallback(s3, bucket, name, trackShaderMaterial, animationEngine, files) {
-
   if (files) {
     for (let file of files) {
       file = file.split(/.*[\/|\\]/)[1];
@@ -339,7 +339,7 @@ export async function loadTracksCallback(s3, bucket, name, trackShaderMaterial, 
 }
 
 async function loadTracksCallbackHelper (s3, bucket, name, trackShaderMaterial, animationEngine, trackFileName, trackName) {
-	await loadTracks(s3, bucket, name, trackShaderMaterial, animationEngine, (trackGeometries) => {
+	await loadTracks(s3, bucket, name, trackFileName, trackShaderMaterial, animationEngine, (trackGeometries) => {
 		const trackLayer = new THREE.Group();
 		trackLayer.name = trackName;
 		for (let ii = 0, len = trackGeometries.bbox.length; ii < len; ii++) {


### PR DESCRIPTION
We will need this for debugging tracks in the coming weeks and was easy enough to finish from my previous branch. Colors default `tracks.fb` file as green, and all others as purple. 

![Screenshot from 2020-08-25 12-42-04](https://user-images.githubusercontent.com/62671258/91203414-0f737680-e6d1-11ea-84bc-f7d0f077617e.png)





