### PR TITLE
Update local spine script to use point validity and point annotation status

### DIFF
--- a/common/playbar.js
+++ b/common/playbar.js
@@ -155,19 +155,22 @@ export function createPlaybar () {
         const laneLeft = window.viewer.scene.scene.getChildByName("Lane Left");
         download(JSON.stringify(laneLeft.points, null, 2), "lane-left.json");
       } else {
-        download(JSON.stringify(laneLeftSegments.getFinalPoints(), null, 2), "lane-left.json");
+        const polyline = laneLeftSegments.getFinalPoints();
+        download(JSON.stringify(polyline.points, null, 2), "lane-left.json");
+        download(JSON.stringify(polyline.pointValidities, null, 2), "lane-left-validities.json");
+        download(JSON.stringify(polyline.pointAnnotations, null, 2), "lane-left-annotations.json");
       }
     } catch (e) {
       console.error("Couldn't download left lane vertices: ", e);
     }
 
     // Download Lane Spine Vertices:
-    try {
-      const laneSpine = window.viewer.scene.scene.getChildByName("Lane Spine");
-      download(JSON.stringify(laneSpine.points, null, 2), "lane-spine.json", "text/plain");
-    } catch (e) {
-      console.error("Couldn't download lane spine vertices: ", e);
-    }
+    // try {
+    //   const laneSpine = window.viewer.scene.scene.getChildByName("Lane Spine");
+    //   download(JSON.stringify(laneSpine.points, null, 2), "lane-spine.json", "text/plain");
+    // } catch (e) {
+    //   console.error("Couldn't download lane spine vertices: ", e);
+    // }
 
     // Download Right Lane Vertices:
     try {
@@ -176,7 +179,10 @@ export function createPlaybar () {
         const laneRight = window.viewer.scene.scene.getChildByName("Lane Right");
         download(JSON.stringify(laneRight.points, null, 2), "lane-right.json", "text/plain");
       } else {
-        download(JSON.stringify(laneRightSegments.getFinalPoints(), null, 2), "lane-right.json", "text/plain");
+        const polyline = laneRightSegments.getFinalPoints();
+        download(JSON.stringify(polyline.points, null, 2), "lane-right.json");
+        download(JSON.stringify(polyline.pointValidities, null, 2), "lane-right-validities.json");
+        download(JSON.stringify(polyline.pointAnnotations, null, 2), "lane-right-annotations.json");
       }
     } catch (e) {
       console.error("Couldn't download right lane vertices: ", e);
@@ -423,8 +429,8 @@ function saveLaneChanges () {
     lane.left = laneLeft.points;
   } else {
     const leftPointsAndValidities = laneLeftSegments.getFinalPoints();
-    lane.left = leftPointsAndValidities.finalPoints;
-    lane.leftPointValidity = leftPointsAndValidities.finalPointValidities;
+    lane.left = leftPointsAndValidities.points;
+    lane.leftPointValidity = leftPointsAndValidities.pointValidities;
   }
 
   // Right Lane Vertices:
@@ -434,8 +440,8 @@ function saveLaneChanges () {
     lane.right = laneRight.points;
   } else {
     const rightPointsAndValidities = laneRightSegments.getFinalPoints();
-    lane.right = rightPointsAndValidities.finalPoints;
-    lane.rightPointValidity = rightPointsAndValidities.finalPointValidities;
+    lane.right = rightPointsAndValidities.points;
+    lane.rightPointValidity = rightPointsAndValidities.pointValidities;
   }
   callUpdateLanesLambdaFunction(bucket, name, lane);
 }

--- a/demo/LaneSegments.js
+++ b/demo/LaneSegments.js
@@ -12,6 +12,8 @@ export class LaneSegments extends THREE.Object3D {
     this.outPoints.push([])
     this.outValidities = [];
     this.outValidities.push([]);
+    this.outAnnotations = [];
+    this.outAnnotations.push([]);
   }
 
   initializeSegment(subName) { // have to be a callback?
@@ -26,6 +28,7 @@ export class LaneSegments extends THREE.Object3D {
     this.offsets.push(0);
     this.outPoints.push([]);
     this.outValidities.push([]);
+    this.outAnnotations.push([]);
   };
 
   finalizeSegment() {
@@ -33,11 +36,12 @@ export class LaneSegments extends THREE.Object3D {
     this.add(this.segments[this.segments.length-1]);
   };
 
-  incrementOffset(point, pointValidity) {
+  incrementOffset(point, pointValidity, pointAnnotation) {
     // increment latest offset and add point to latest outPoints
     this.offsets[this.offsets.length-1] = this.offsets[this.offsets.length-1]+1;
     this.outPoints[this.outPoints.length-1].push({ position: point });
     this.outValidities[this.outValidities.length-1].push({ pointValidity: pointValidity });
+    this.outAnnotations[this.outAnnotations.length-1].push({ pointAnnotation: pointAnnotation });
   };
 
   addSegmentMarker(point) {
@@ -48,26 +52,37 @@ export class LaneSegments extends THREE.Object3D {
   getFinalPoints() {
     var finalPoints = [];
     var finalPointValidities = [];
+    var finalPointAnnotations = [];
 
     finalPoints = finalPoints.concat(this.outPoints[0]);
     var outPointValidities = this.outValiditiesHelper(0);
     finalPointValidities = finalPointValidities.concat(outPointValidities);
+    var outPointAnnotations = this.outAnnotationsHelper(0);
+    finalPointAnnotations = finalPointAnnotations.concat(outPointAnnotations);
 
     for (let si=0, sLen=this.segments.length; si<sLen; si++) {
+      // points
       finalPoints = finalPoints.concat(this.segments[si].points);
       finalPoints = finalPoints.concat(this.outPoints[si+1]);
+      // validities
       const segmentValidities = Array(this.segments[si].points.length).fill(0);
       finalPointValidities = finalPointValidities.concat(segmentValidities);
       outPointValidities = this.outValiditiesHelper(si+1);
       finalPointValidities = finalPointValidities.concat(outPointValidities);
+      // annotations
+      const segmentAnnotations = Array(this.segments[si].points.length).fill(1);
+      finalPointAnnotations = finalPointAnnotations.concat(segmentAnnotations);
+      outPointAnnotations = this.outAnnotationsHelper(si+1);
+      finalPointAnnotations = finalPointAnnotations.concat(outPointAnnotations);
     }
     return {
-      finalPoints: finalPoints,
-      finalPointValidities: finalPointValidities
+      points: finalPoints,
+      pointValidities: finalPointValidities,
+      pointAnnotations: finalPointAnnotations
     };
   };
 
-  updateSegments(clonedBoxes, prevIsContains, point, pointValidity, index, lengthArray) {
+  updateSegments(clonedBoxes, prevIsContains, point, pointValidity, pointAnnotation, index, lengthArray) {
     let newIsContains = false;
     for (let bbi=0, bbLen=clonedBoxes.length; bbi<bbLen; bbi++) {
       const isContains = clonedBoxes[bbi].containsPoint(new THREE.Vector3(point.x(), point.y(), point.z()));
@@ -85,7 +100,7 @@ export class LaneSegments extends THREE.Object3D {
     if (newIsContains) {
       this.addSegmentMarker(new THREE.Vector3(point.x(), point.y(), point.z()));
     } else {
-      this.incrementOffset(new THREE.Vector3(point.x(), point.y(), point.z()), pointValidity);
+      this.incrementOffset(new THREE.Vector3(point.x(), point.y(), point.z()), pointValidity, pointAnnotation);
     }
 
     // edge case if a segment exists at the end
@@ -93,7 +108,7 @@ export class LaneSegments extends THREE.Object3D {
       this.finalizeSegment();
     }
 
-    return newIsContains
+    return newIsContains;
   };
 
   outValiditiesHelper(index) {
@@ -103,5 +118,13 @@ export class LaneSegments extends THREE.Object3D {
     }
     return outPointValidities;
   };
-  
+
+  outAnnotationsHelper(index) {
+    const outPointAnnotations = []
+    for (const annotation of this.outAnnotations[index]) {
+      outPointAnnotations.push(annotation.pointAnnotation);
+    }
+    return outPointAnnotations;
+  };
+
 };

--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -127,7 +127,7 @@ async function createLaneGeometries (lanes, supplierNum, annotationMode, volumes
         if (volumes.length === 0) {
           laneLeft.addMarker(new THREE.Vector3(left.x(), left.y(), left.z()));
         } else {
-          isContains = leftLaneSegments.updateSegments(clonedBoxes, isContains, left, lane.leftPointValidity(jj), jj, numVertices);
+          isContains = leftLaneSegments.updateSegments(clonedBoxes, isContains, left, lane.leftPointValidity(jj), lane.leftPointAnnotationStatus(jj), jj, numVertices);
         }
       } else {
         geometryLeft.vertices.push(new THREE.Vector3(left.x(), left.y(), left.z()));
@@ -146,7 +146,7 @@ async function createLaneGeometries (lanes, supplierNum, annotationMode, volumes
         if (volumes.length === 0) {
           laneRight.addMarker(new THREE.Vector3(right.x(), right.y(), right.z()));
         } else {
-          isContains = rightLaneSegments.updateSegments(clonedBoxes, isContains, right, lane.rightPointValidity(jj), jj, numVertices);
+          isContains = rightLaneSegments.updateSegments(clonedBoxes, isContains, right, lane.rightPointValidity(jj), lane.rightPointAnnotationStatus(jj), jj, numVertices);
         }
       } else {
         geometryRight.vertices.push(new THREE.Vector3(right.x(), right.y(), right.z()));


### PR DESCRIPTION
Adds support for point validity and point annotation status in potree script for generating spine. Makes changes to potree to output json files for point validity arrays and point annotation status arrays for left and right polylines. Next step is to add support to AWS Lambda script for point annotation status arrays.



