### PR TITLE
Fixed sensor readings names

### DIFF
--- a/demo/controlPointLoader.js
+++ b/demo/controlPointLoader.js
@@ -332,8 +332,17 @@ function getControlPointName (controlPointType) {
   let words = controlPointType.slice(0, -3);
   // remove 'viz_Spheres3D_' prefix
   words = words.substring(13);
-  // split on '_', join into display name
   words = words.split("_");
+
+  if (words.includes("LaneSense")) {
+    words = words.map(word => word === "LaneSense" ? "Lane Sense" : word);
+  }
+  else {
+    // TODO: This is hacky, and should be changed when fork is private
+    if (words.length > 1) words[1] = "Lane Polynomial";
+    if (words.length > 3) words[3] = "";
+  }
+
   words = words.join(" ");
   return words;
 }

--- a/demo/trackLoader.js
+++ b/demo/trackLoader.js
@@ -343,7 +343,8 @@ export async function loadTracksCallback(s3, bucket, name, trackShaderMaterial, 
 async function loadTracksCallbackHelper (s3, bucket, name, trackShaderMaterial, animationEngine, trackFileName, trackName) {
 	await loadTracks(s3, bucket, name, trackFileName, trackShaderMaterial, animationEngine, (trackGeometries) => {
 		const trackLayer = new THREE.Group();
-		trackLayer.name = trackName;
+    trackLayer.name = trackName;
+    trackLayer.visible = trackName === 'Tracked Objects'
 		for (let ii = 0, len = trackGeometries.bbox.length; ii < len; ii++) {
 			trackLayer.add(trackGeometries.bbox[ii]);
 			// viewer.scene.scene.add(trackGeometries.bbox[ii]); // Original


### PR DESCRIPTION
- "LaneSense" is now "Lane Sense" in the potree sidebar
- "SPP" is now "Lane Polynomial" in the potree sidebar
- "Ford" has been filtered out of any words in the sidebar (there were no instances of this, but this will prevent Ford from appearing in the future)
- Only tracks.fb are shown by default now. Other tracks aren't checked by default.





