### PR TITLE
Fixed loading for datasets with no lanes

### DIFF
--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -14,7 +14,7 @@ export const laneDownloads = async (datasetFiles) => {
                                   "GroundTruth_generated.js", // 5_Schemas
                                   "../data/lanes.fb",
                                   "../schemas/GroundTruth_generated.js");
-  if (laneFiles.hasOwnProperty("fileCount")) laneFiles.fileCount = 1;
+  if (laneFiles?.hasOwnProperty("fileCount")) laneFiles.fileCount = 1;
   return laneFiles
 }
 


### PR DESCRIPTION
Fixed issue that prevented datasets with no lanes files from loading.




