### PR TITLE
Hide un-annotated lanes by default

### DIFF
--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -7,14 +7,30 @@ import { getFbFileInfo } from "./loaderUtilities.js";
 
 
 let laneFiles = null;
+let showLanesDefault = true;
+
 export const laneDownloads = async (datasetFiles) => {
   laneFiles = await getFbFileInfo(datasetFiles,
-                                  "lanes.fb",
+                                  "annotated-lanes.fb",
                                   "2_Truth",
                                   "GroundTruth_generated.js", // 5_Schemas
                                   "../data/lanes.fb",
-                                  "../schemas/GroundTruth_generated.js");
+                                  "../schemas/GroundTruth_generated.js",
+                                  true);
+
+  if (!laneFiles) {
+    laneFiles = await getFbFileInfo(datasetFiles,
+                                    "lanes.fb",
+                                    "2_Truth",
+                                    "GroundTruth_generated.js", // 5_Schemas
+                                    "../data/lanes.fb",
+                                    "../schemas/GroundTruth_generated.js",
+                                    true);
+    showLanesDefault = false;
+  }
+
   if (laneFiles?.hasOwnProperty("fileCount")) laneFiles.fileCount = 1;
+
   return laneFiles
 }
 
@@ -351,6 +367,7 @@ function addLaneGeometries (laneGeometries, lanesLayer) {
   for (let ii = 0, len = laneGeometries.all.length; ii < len; ii++) {
     lanesLayer.add(laneGeometries.all[ii]);
   }
+  lanesLayer.visible = showLanesDefault;
   viewer.scene.scene.add(lanesLayer);
 
   // add lane anomaly geometries

--- a/demo/loaderUtilities.js
+++ b/demo/loaderUtilities.js
@@ -23,12 +23,12 @@ async function existsOrNull(path) {
     })
 }
 
-export const getFbFileInfo = async (datasetFiles, objNameMatch, objFolderMatch, schemaMatch, localObj, localSchema) =>
+export const getFbFileInfo = async (datasetFiles, objNameMatch, objFolderMatch, schemaMatch, localObj, localSchema, exactMatch = false) =>
   {
     if (datasetFiles) {
-      const objectName = datasetFiles.filter(path => path.endsWith(objNameMatch) && path.includes(objFolderMatch))[0];
+      const objectName = datasetFiles.filter(path => exactMatch ? path.split("/")[path.split("/").length - 1] === objNameMatch : path.endsWith(objNameMatch) && path.includes(objFolderMatch))[0];
       const schemaFile = datasetFiles.filter(path => path.endsWith(schemaMatch))[0];
-      const fileCount = datasetFiles.filter(path => path.endsWith(objNameMatch) && path.includes(objFolderMatch))?.length;
+      const fileCount = datasetFiles.filter(path => exactMatch ? path.split("/")[path.split("/").length - 1] === objNameMatch : path.endsWith(objNameMatch) && path.includes(objFolderMatch))?.length;
       return objectName && schemaFile && {objectName, schemaFile, fileCount};
     } else {
       const objectName = await existsOrNull(localObj);


### PR DESCRIPTION
This will hide lanes by default if no file named "annotated-lanes.fb" is present.





