### PR TITLE
Fixed slow anomaly loading

### DIFF
--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -334,7 +334,9 @@ function addAnnotations (laneGeometries) {
       position: laneGeometries.leftAnomalies[0],
       collapseThreshold: 0
     });
-    aAnomalies.add(populateAnomaliesHelper(aLeft, laneGeometries.leftAnomalies, 'Left'))
+    aAnomalies.children.push(aLeft);
+    aLeft.parent = aAnomalies;
+    populateAnomaliesHelper(aLeft, laneGeometries.leftAnomalies, 'Left');
   }
 
   if (laneGeometries.rightAnomalies.length !== 0) {
@@ -344,11 +346,14 @@ function addAnnotations (laneGeometries) {
       position: laneGeometries.rightAnomalies[0],
       collapseThreshold: 0
     });
-    aAnomalies.add(populateAnomaliesHelper(aRight, laneGeometries.rightAnomalies, 'Right'))
+    aAnomalies.children.push(aRight);
+    aRight.parent = aAnomalies;
+    populateAnomaliesHelper(aRight, laneGeometries.rightAnomalies, 'Right');
   }
 }
 
 function populateAnomaliesHelper (annotation, anomalies, name) {
+  const anomaliesArray = [];
   for (let ii = 0, len = anomalies.length; ii < len; ii++) {
     const point = anomalies[ii];
     const aAnomaly = new Potree.Annotation({
@@ -357,9 +362,9 @@ function populateAnomaliesHelper (annotation, anomalies, name) {
       cameraPosition: new THREE.Vector3(point.x, point.y, point.z + 20),
       cameraTarget: point
     });
-    annotation.add(aAnomaly);
+    anomaliesArray.push(aAnomaly);
   }
-  return annotation;
+  annotation.addMultiple(viewer.scene.annotations, anomaliesArray);
 }
 
 // Adds lane geometries to viewer

--- a/src/Annotation.js
+++ b/src/Annotation.js
@@ -390,6 +390,16 @@ export class Annotation extends EventDispatcher {
 		}
 	}
 
+	addMultiple (root, annotations) {
+		this.children.push(...annotations);
+		annotations.forEach(annotation => annotation.parent = this);
+
+		root.dispatchEvent({
+			'type': 'annotation_added',
+			'annotation': this
+		});
+	}
+
 	level () {
 		if (this.parent === null) {
 			return 0;


### PR DESCRIPTION
This fixes the slow anomaly loading, with one drawback. With this fix, individual anomaly annotations cannot be selected/deselected, but I think this is a worthwhile trade-off. See the images attached for more details.
Old Sidebar:
![old-anomalies](https://user-images.githubusercontent.com/52417722/100295098-baa4fd80-2f56-11eb-8da8-bd848de205ab.PNG)
New Sidebar:
![new-anomalies](https://user-images.githubusercontent.com/52417722/100295097-ba0c6700-2f56-11eb-9e70-b50c15e8b316.PNG)







