### PR TITLE
Turn off customer sensor data by default

### DIFF
--- a/demo/controlPointLoader.js
+++ b/demo/controlPointLoader.js
@@ -28,6 +28,7 @@ async function loadControlPointsCallbackHelper (s3, bucket, name, animationEngin
 
     const controlPointLayer = new THREE.Group();
     controlPointLayer.name = getControlPointName(controlPointType);
+    controlPointLayer.visible = false;
     mesh.position.copy(offset)
     controlPointLayer.add(mesh);
 

--- a/demo/detectionLoader.js
+++ b/demo/detectionLoader.js
@@ -202,6 +202,7 @@ window.detectionsLoaded = false;
       if (detectionGeometries != null) {
         let detectionLayer = new THREE.Group();
         detectionLayer.name = "Object Detections";
+        detectionLayer.visible = false;
         for (let ii = 0, len = detectionGeometries.bbox.length; ii < len; ii++) {
           detectionLayer.add(detectionGeometries.bbox[ii]);
         }

--- a/demo/radarLoader.js
+++ b/demo/radarLoader.js
@@ -167,7 +167,8 @@ export function addLoadRadarButton() {
 				let shaderMaterial = getShaderMaterial()
 				var material = new THREE.PointsMaterial({ size: 1.0 });
 				var mesh = new THREE.Points(geometry, shaderMaterial);
-				mesh.name = "radar";
+        mesh.name = "radar";
+        mesh.visible = false;
 				// debugger; //radar tracks added?
 				viewer.scene.scene.add(mesh);
 				viewer.scene.dispatchEvent({ "type": "sensor_layer_added", "sensorLayer": mesh });

--- a/demo/radarVisualizationLoader.js
+++ b/demo/radarVisualizationLoader.js
@@ -33,6 +33,7 @@ async function loadRadarVisualizationCallbackHelper (radarVisualizationType) {
 
     const radarVisualizationLayer = new THREE.Group();
     radarVisualizationLayer.name = getRadarVisualizationName(radarVisualizationType);
+    radarVisualizationLayer.visible = false;
     mesh.position.copy(offset);
     radarVisualizationLayer.add(mesh);
 

--- a/demo/remLoader.js
+++ b/demo/remLoader.js
@@ -149,6 +149,7 @@ export async function loadRemCallback(s3, bucket, name, animationEngine) {
 	await loadRem(s3, bucket, name, remShaderMaterial, animationEngine, (sphereMeshes) => {
 		const remLayer = new THREE.Group();
     remLayer.name = "REM Control Points";
+    remLayer.visible = false;
     sphereMeshes.forEach(mesh => remLayer.add(mesh))
 
 		viewer.scene.scene.add(remLayer);


### PR DESCRIPTION
Turns off the following customer sensor layers by default:
- detection
- radar
- object fusion
- rem
I didn't touch object fusion tracks because most of those, except the default "Object Fusion Tracks", are already turned off by default





