### PR TITLE
Feat/new update lanes

### DIFF
--- a/lambda/py/lambda_function.py
+++ b/lambda/py/lambda_function.py
@@ -1,0 +1,29 @@
+import json
+import update_lanes
+import os
+import sys
+import parser
+import argparse
+import json
+import boto3
+import logging
+from botocore.exceptions import ClientError
+import flatbuffers
+import Lanes
+import Lane
+import Vec3
+import PointValidity
+import PointAnnotationStatus
+import numpy as np
+from shapely.geometry import LineString, Point, MultiPoint, box
+from shapely.ops import nearest_points
+from scipy.spatial import cKDTree
+from io import BytesIO
+
+
+def lambda_handler(event, context):
+    update_lanes.getUpdatedSpine(event)
+    return {
+        'statusCode': 200
+    }
+

--- a/lambda/py/update_lanes.py
+++ b/lambda/py/update_lanes.py
@@ -1,0 +1,554 @@
+import os
+import sys
+import parser
+import argparse
+import json
+import boto3
+import logging
+from botocore.exceptions import ClientError
+import flatbuffers
+import Lanes
+import Lane
+import Vec3
+import PointValidity
+import PointAnnotationStatus
+import numpy as np
+from shapely.geometry import LineString, Point, MultiPoint, box
+from shapely.ops import nearest_points
+from scipy.spatial import cKDTree
+from io import BytesIO
+
+def create_original_lanes(region, bucket, name):
+    s3 = boto3.client('s3', region_name = region)
+    try:
+        s3.head_object(Bucket=bucket, Key='/'.join([name, '2_Truth', 'original-lanes.fb']))
+        # file exists
+    except ClientError:
+        # file does not exist
+        copy_source = {
+            'Bucket': bucket,
+            'Key': '/'.join([name, '2_Truth', 'lanes.fb'])
+        }
+        # write file
+        s3.copy(copy_source, bucket, '/'.join([name, '2_Truth', 'original-lanes.fb']))
+    
+def write_buffer_to_s3(region, bucket, name, builder):
+    output_data = builder.Output()
+    size = len(output_data).to_bytes(4, byteorder='little', signed=True)
+    bytes_array = bytearray(size) + output_data
+    key = '/'.join([name, '2_Truth/lanes.fb'])
+    s3 = boto3.client('s3', region_name = region)
+    try:
+        response = s3.put_object(Body=bytes_array, Bucket=bucket, Key=key)
+    except ClientError as e:
+        logging.error(e)
+
+def to_bytes(n, length, endianess='big'):
+    h = '%x' % n
+    s = ('0'*(len(h) % 2) + h).zfill(length*2).decode('hex')
+    return s if endianess == 'big' else s[::-1]
+
+def write_buffer(builder, filename, createNew = True):
+    if not createNew:
+        flag = "ab"
+        print("APPENDING")
+    else:
+        flag = "wb"
+        print("NEW")
+
+    file = open(filename, flag)
+    output_data = builder.Output()
+#     size = len(output_data).to_bytes(4, byteorder='little', signed=True)
+    size = len(output_data).to_bytes(4, byteorder='little', signed=True)
+    print("Size: {}".format(len(output_data)))
+    file.write(size)
+    file.write(output_data)
+
+
+def create_vector(builder, nparray, flag):
+    numVals = nparray.shape[0]
+
+    if flag == 'left':
+        Lane.LaneStartLeftVector(builder, numVals)
+        return vec3VectorBuilderHelper(builder, numVals, nparray)
+    elif flag == 'right':
+        Lane.LaneStartRightVector(builder, numVals)
+        return vec3VectorBuilderHelper(builder, numVals, nparray)
+    elif flag == 'spine':
+        Lane.LaneStartSpineVector(builder, numVals)
+        return vec3VectorBuilderHelper(builder, numVals, nparray)
+    elif flag == 'create_left_point_validities':
+        Lane.LaneStartLeftPointValidityVector(builder, numVals)
+        return enumByte2VectorBuilderHelper(builder, numVals)
+    elif flag == 'create_right_point_validities':
+        Lane.LaneStartRightPointValidityVector(builder, numVals)
+        return enumByte2VectorBuilderHelper(builder, numVals)
+    elif flag == 'left_point_validities':
+        Lane.LaneStartLeftPointValidityVector(builder, numVals)
+        return enumVector2VectorBuilderHelper(builder, numVals, nparray)
+    elif flag == 'right_point_validities':
+        Lane.LaneStartRightPointValidityVector(builder, numVals)
+        return enumVector2VectorBuilderHelper(builder, numVals, nparray)
+    elif flag == 'create_left_point_annotation_statuses':
+        Lane.LaneStartLeftPointAnnotationStatusVector(builder, numVals)
+        return enumByte2VectorBuilderHelper(builder, numVals, byte=1)
+    elif flag == 'create_right_point_annotation_statuses':
+        Lane.LaneStartRightPointAnnotationStatusVector(builder, numVals)
+        return enumByte2VectorBuilderHelper(builder, numVals, byte=1)
+    elif flag == 'left_point_annotations':
+        Lane.LaneStartLeftPointAnnotationStatusVector(builder, numVals)
+        return enumVector2VectorBuilderHelper(builder, numVals, nparray)
+    elif flag == 'right_point_annotations':
+        Lane.LaneStartRightPointAnnotationStatusVector(builder, numVals)
+        return enumVector2VectorBuilderHelper(builder, numVals, nparray)
+
+def vec3VectorBuilderHelper(builder, numVals, nparray):
+    for i in range(numVals)[::-1]:
+        val = Vec3.CreateVec3(builder, nparray[i, 0], nparray[i, 1], nparray[i, 2])
+    return builder.EndVector(numVals)
+
+def enumByte2VectorBuilderHelper(builder, numVals, byte=0):
+    for i in range(numVals)[::-1]:
+        builder.PrependByte(byte)
+    return builder.EndVector(numVals)
+
+def enumVector2VectorBuilderHelper(builder, numVals, nparray):
+    for i in range(numVals)[::-1]:
+        builder.PrependByte(nparray[i])
+    return builder.EndVector(numVals)
+
+def outputFlatbuffer(laneSegments, leftPointValidity, rightPointValidity, leftPointAnnotationStatus, rightPointAnnotationStatus):
+    temp_lanes = []
+
+    for i in range(len(laneSegments)):
+        laneSegment = laneSegments[i]
+        builder = flatbuffers.Builder(1024)
+
+        lefts = create_vector(builder, laneSegment['left'], 'left')
+        rights = create_vector(builder, laneSegment['right'], 'right')
+        spines = create_vector(builder, laneSegment['spine'], 'spine')
+
+        # left point annotation status
+        if len(leftPointAnnotationStatus) == 0:
+            left_point_annotation_statuses = create_vector(builder, laneSegment['left'], 'create_left_point_annotation_statuses')
+        else:
+            left_point_annotation_statuses = create_vector(builder, np.array(leftPointAnnotationStatus), 'left_point_annotations')
+
+        # right point annotation status
+        if len(rightPointAnnotationStatus) == 0:
+            right_point_annotation_statuses = create_vector(builder, laneSegment['right'], 'create_right_point_annotation_statuses')
+        else:
+            right_point_annotation_statuses = create_vector(builder, np.array(rightPointAnnotationStatus), 'right_point_annotations')
+
+        # left point validity
+        if len(leftPointValidity) == 0:
+            left_point_validities = create_vector(builder, laneSegment['left'], 'create_left_point_validities')
+        else:
+            left_point_validities = create_vector(builder, np.array(leftPointValidity), 'left_point_validities')
+
+        # right point validity
+        if len(rightPointValidity) == 0:
+            right_point_validities = create_vector(builder, laneSegment['right'], 'create_right_point_validities')
+        else:
+            right_point_validities = create_vector(builder, np.array(rightPointValidity), 'right_point_validities')
+
+        # Start Lane:
+        Lane.LaneStart(builder)
+
+        # Set ID:
+        Lane.LaneAddId(builder, 0)
+
+        # Add Lefts:
+        Lane.LaneAddLeft(builder, lefts)
+
+        # Add Rights:
+        Lane.LaneAddRight(builder, rights)
+
+        # Add Spine:
+        Lane.LaneAddSpine(builder, spines)
+
+        # Add PointValidity
+        Lane.LaneAddLeftPointValidity(builder, left_point_validities)
+        Lane.LaneAddRightPointValidity(builder, right_point_validities)
+
+        # Add PointAnnotationStatus
+        Lane.LaneAddLeftPointAnnotationStatus(builder, left_point_annotation_statuses)
+        Lane.LaneAddRightPointAnnotationStatus(builder, right_point_annotation_statuses)
+
+        lane = Lane.LaneEnd(builder)
+        builder.Finish(lane)
+        temp_lanes.append(lane)
+
+        return builder
+        
+def getXYZ(data):
+    x = data['position']['x']
+    y = data['position']['y']
+    z = data['position']['z']
+    return [x, y, z]
+
+def get_heading(pt1, pt2):
+    p1 = np.array(pt1).transpose()
+    p2 = np.array(pt2).transpose()
+    delta = p2-p1
+    heading = np.arctan2(delta[1], delta[0])
+    return heading
+
+def min_angle(theta, bounds=[-np.pi, np.pi]):
+    while theta < bounds[0]:
+        theta += 2*np.pi
+    while theta > bounds[1]:
+        theta -= 2*np.pi
+    return theta
+
+def min_angle_diff(theta1, theta2, bounds=[-np.pi, np.pi]):
+    delta = theta2 - theta1
+    return min_angle(delta)
+
+# For local
+def getUpdatedSpine(inputFileLeft, inputFileRight, upsampleValue, verbose):
+    leftData = json.loads(open(inputFileLeft, 'r').read())
+    rightData = json.loads(open(inputFileRight, 'r').read())
+
+    return getLinesFromJson(leftData, rightData, upsampleValue, verbose)
+
+# For Lambda
+def getUpdatedSpine(input):
+    leftData = input['left']
+    rightData = input['right']
+    upsampleValue = input['upsampleValue']
+    verbose = input['verbose']
+    region = input["region"]
+    bucket = input['bucket']
+    name = input['name']
+
+    laneSegments = getLinesFromJson(leftData, rightData, upsampleValue, verbose)
+    builder = outputFlatbuffer(laneSegments, input["leftPointValidity"], input["rightPointValidity"], ?, ?)
+
+    create_original_lanes(region, bucket, name)
+    write_buffer_to_s3(region, bucket, name, builder)
+
+def getLinesFromJson(leftData, rightData, upsampleValue, verbose):
+    laneChangeNNRange = 5 # meters
+    rightLaneNeighborPointsQueryNumber = 10 # number of neighbors
+    laneChangeHeadingThresh = np.pi/4 # Radians
+    prevPointSuppressionRadius = .1 # meters
+
+    laneSegments = []
+    laneLefts = []
+    laneSpines = []
+    laneRights = []
+
+
+    # Get Left/Right Line Vertices
+    for i in range(len(leftData)):
+        laneLefts.append(  getXYZ(leftData[i]) )
+    for i in range(len(rightData)):
+        laneRights.append( getXYZ(rightData[i]) )
+
+    # Upsample the points
+    if (upsampleValue):
+        upsample(laneLefts, laneRights, upsampleValue)
+
+    # Compute Spine Vertices (using left lane as reference):
+    rightLine = LineString(laneRights) # Create shapely linestring for right line
+    kdtree = cKDTree(laneRights) # Create KD-Tree for right lane points as well
+    lastIdx = len(laneLefts)-1
+    for ii in range(lastIdx+1):
+        p = laneLefts[ii]
+        pt = Point(p)
+        projPt = rightLine.interpolate(rightLine.project(pt))
+        minLine = LineString([pt, projPt]) # Shortest line from pt to right line
+        spinePt = minLine.interpolate(minLine.length/2)
+
+        if ii != 0 and ii != lastIdx:
+            lastPt = Point(laneLefts[ii-1])
+            nextPt = Point(laneLefts[ii+1])
+            lastHeading = get_heading(lastPt, pt)
+            nextHeading = get_heading(pt, nextPt)
+
+            leftHeadingDelta = min_angle_diff(lastHeading, nextHeading)
+
+            if np.abs(leftHeadingDelta) > laneChangeHeadingThresh:
+
+                if verbose:
+                    print("Lane Change Detected: \n\tii: {}\theading: {}\tpos: {}".format(ii, leftHeadingDelta, p))
+                    print("\tLast Left Heading: {}".format(lastHeading))
+                    print("\tNext Left Heading: {}".format(nextHeading))
+
+                # Get idxs of nearby right points
+                dists_nn, idxs_nn = kdtree.query(p, rightLaneNeighborPointsQueryNumber)
+                if verbose:
+                    print("\tRight Point Idxs (Before): {}".format(idxs_nn))
+                    print("\tRight Point Dists (Before): {}".format(dists_nn))
+                filterer = dists_nn <= laneChangeNNRange
+                dists_nn = dists_nn[filterer]
+                idxs_nn = idxs_nn[filterer]
+
+                if len(idxs_nn) == 0:
+                    continue
+
+                idxs_nn_min = max(idxs_nn.min()-1, 0)
+                idxs_nn_max = min(idxs_nn.max()+2, len(laneRights))
+
+                idxs_nn = np.arange(idxs_nn_min, idxs_nn_max) # Closed set of points approximately within laneChangeNNRange of pt
+
+                if len(idxs_nn) < 3:
+                    print("Not Enough Neighbors for pt: [idx: {}, pos: {}]".format(ii, p))
+                    continue
+
+                # Find closest lane change point in right line:
+                rightPts = np.array(laneRights)[idxs_nn]
+                rightPtDeltas = np.diff(rightPts, axis=0)
+                rightHeadings = np.arctan2(rightPtDeltas[:,1], rightPtDeltas[:,0])
+                rightHeadingDeltas = np.array([min_angle(x) for x in np.diff(rightHeadings)])
+                # rightHeadingDeltas = np.diff(rightHeadings)
+
+                if rightHeadingDeltas.shape[0] == 0:
+                    print("No RightHeadingDeltas for pt: [idx: {}, pos: {}]".format(ii, p))
+                    continue
+
+                leftRightHeadingDeltaSimilarity = np.abs(rightHeadingDeltas-leftHeadingDelta)
+                bestRightHeadingIdx = leftRightHeadingDeltaSimilarity.argmin() + 1
+                rightPtIdx = idxs_nn[bestRightHeadingIdx] # +1 inside []
+
+                if verbose:
+                    print("\tRight Point Idxs (After): {}".format(idxs_nn))
+                    print("\tRight Heading Diffs: {}".format(rightHeadingDeltas))
+                    print("\tRight Heading Diffs: {}".format(leftRightHeadingDeltaSimilarity))
+                    print("\tBest Right Heading Idx: {}".format(bestRightHeadingIdx))
+                    print("\trightPtIdx: {}".format(rightPtIdx))
+
+                # Simple Solution (Just Compute Spine Point using the Right Lane Change Point and append):
+                rightPt = Point(laneRights[rightPtIdx])
+                minLine = LineString([pt, rightPt])
+                spinePt2 = minLine.interpolate(minLine.length/2)
+
+                p1 = np.array(laneSpines[-1][:2])
+                p2 = np.array(spinePt2.xy).flatten()
+
+                if np.linalg.norm((p2-p1)) > prevPointSuppressionRadius: # If spine point is farther than thresh from previous point append
+                    laneSpines.append([spinePt2.x, spinePt2.y, spinePt2.z])
+
+
+        # Don't append lane spine if duplicate (within 10cm of last) or if going backwards:
+        def should_append(spinePt):
+
+            if len(laneSpines) < 1:
+                return True
+
+            p1 = np.array(laneSpines[-1])[:2]
+            p2 = np.array(spinePt.xy).flatten()
+
+            if np.linalg.norm(p2-p1) < prevPointSuppressionRadius:
+                print("Skipping lane spine point-- too close to existing spine point")
+                return False
+            else:
+                if len(laneSpines) >=2:
+                    p0 = np.array(laneSpines[-2])[:2]
+
+                    v1 = (p1-p0)[:2]
+                    v2 = (p2-p1)[:2]
+
+                    magV1 = np.linalg.norm(v1)
+                    magV2 = np.linalg.norm(v2)
+
+                    cosHeading = np.dot(v1, v2)/(magV1 * magV2)
+
+                    if np.abs(cosHeading - (-1)) < .1:
+                        print("Skipping lane spine point -- going backwards")
+                        return False
+                    else:
+                        return True
+                else:
+                    return True
+
+
+        if should_append(spinePt):
+            laneSpines.append([spinePt.x, spinePt.y, spinePt.z])
+
+
+    # Convert to Numpy arrays:
+
+    laneSpines = np.array(laneSpines[:len(laneSpines)])
+    laneLefts = np.array(laneLefts[:len(laneLefts)])
+    laneRights = np.array(laneRights[:len(laneRights)])
+
+    laneSegments.append({
+        "left": laneLefts,
+        "right": laneRights,
+        "spine": laneSpines
+    })
+
+    return laneSegments
+
+def plotLines(laneSegments, verbose):
+    first = True
+    for laneSegment in laneSegments:
+        if first:
+            laneSpines = laneSegment['spine']
+            laneLefts = laneSegment['left']
+            laneRights = laneSegment['right']
+            first = False
+        else:
+            laneSpines = np.vstack([laneSpines, laneSegment['spine']])
+            laneLefts = np.vstack([laneLefts, laneSegment['left']])
+            laneRights = np.vstack([laneRights, laneSegment['right']])
+
+
+    spinePts = np.array(laneSpines)
+    spinePtDeltas = np.diff(spinePts, axis=0)
+    spineHeadings = np.arctan2(spinePtDeltas[:,1], spinePtDeltas[:,0])
+    spineHeadingDeltas = np.diff(spineHeadings)
+
+    laneChangeIdxs = np.abs(spineHeadingDeltas) > np.pi/4
+    laneChangeIdxs = np.hstack([[False], laneChangeIdxs, [False]])
+
+    print(laneSpines.shape)
+    fig = plt.figure(figsize=[10,10])
+
+    if verbose:
+        for ii in range(laneLefts.shape[0]):
+            plt.annotate(str(ii), laneLefts[ii,:2])
+        for ii in range(laneRights.shape[0]):
+            plt.annotate(str(ii), laneRights[ii,:2])
+
+
+    plt.plot(laneLefts[:,0], laneLefts[:,1], label="Left Lane")
+    plt.plot(laneRights[:,0], laneRights[:,1], label="Right Lane")
+    plt.plot(laneSpines[:,0], laneSpines[:,1], label="Lane Spine")
+    plt.scatter(laneLefts[:,0], laneLefts[:,1])
+    plt.scatter(laneRights[:,0], laneRights[:,1])
+    plt.scatter(laneSpines[:,0], laneSpines[:,1])
+    plt.plot(laneSpines[laneChangeIdxs,0], laneSpines[laneChangeIdxs,1], 'rD', label="Lane Changes")
+    plt.axis('equal')
+    plt.legend()
+    plt.show()
+    plt.savefig('lanes.pdf')
+
+def multipoint_index(multipoint, point):
+    for i in range(len(multipoint)):
+        if (point.x == multipoint[i].x and point.y == multipoint[i].y):
+            return i
+
+    return None
+
+def upsample_single(lane1, lane2, threshold):
+    # Create a shapely line string for lane2
+    lane2Line = LineString(lane2)
+
+    # Loop through points in lane1
+    for i in range(len(lane1)):
+        # Get the closest point on lane2
+        projection = lane2Line.interpolate(lane2Line.project(Point(lane1[i])))
+
+        # Create bounds in which to check for a neighbor
+        bounds = projection.buffer(threshold)
+
+        # Check if the nearest neighbor to the projection point is within the bounds
+        points = MultiPoint(lane2)
+        nearestPoint = nearest_points(projection, points)[1]
+        if (not bounds.contains(nearestPoint)):
+            # Insert the new neighbor at the correct index
+            index = multipoint_index(points, nearestPoint)
+            if (lane2Line.project(nearestPoint, normalized=True) < lane2Line.project(projection, normalized=True)):
+                index = index + 1
+
+            lane2.insert(index, [projection.x, projection.y, projection.z])
+
+
+def upsample(leftPoints, rightPoints, threshold):
+    upsample_single(leftPoints, rightPoints, threshold)
+    upsample_single(rightPoints, leftPoints, threshold)
+    print("Left size after upsample:", len(leftPoints))
+    print("Right size after upsample:", len(rightPoints))
+    #assert len(leftPoints) == len(rightPoints)
+
+
+def check_lane_spine(laneSegments):
+    # import pdb
+    # pdb.set_trace()
+    leftLine = LineString(laneSegments[0]["left"])
+    spineLine = LineString(laneSegments[0]["spine"])
+    rightLine = LineString(laneSegments[0]["right"])
+
+    left_dists = []
+    right_dists = []
+    distance_steps = np.linspace(0, spineLine.length, spineLine.length+1)
+    for d in distance_steps:
+        pt = spineLine.interpolate(d)
+
+        projPt = leftLine.interpolate(leftLine.project(pt))
+        minLine = LineString([pt, projPt]) # Shortest line from pt to right line
+        left_dists.append(minLine.length)
+
+        projPt = rightLine.interpolate(rightLine.project(pt))
+        minLine = LineString([pt, projPt]) # Shortest line from pt to right line
+        right_dists.append(minLine.length)
+
+    # plt.subplots(21, sharex=True)
+    ax = plt.subplot(211)
+    plt.title("Spine Distance to Nearest Lane Boundary")
+    plt.xlabel("Distance along spine")
+    plt.ylabel("Distance to Lane Boundary")
+    plt.plot(distance_steps/spineLine.length, left_dists, label="Right Lane Boundary")
+    plt.plot(distance_steps/spineLine.length, right_dists, label="Left Lane Boundary")
+    plt.legend()
+    plt.grid(True)
+
+    plt.subplot(212, sharex=ax)
+    plt.title("Spine Distance to Right vs Left Discrepancy")
+    plt.xlabel("Distance along spine")
+    plt.ylabel("Distance to Lane Boundary")
+    plt.plot(distance_steps/spineLine.length, np.array(right_dists) - np.array(left_dists), label="")
+    plt.grid(True)
+
+    plt.legend()
+    plt.show()
+
+def getDataFromJson(inputFile):
+    return json.loads(open(inputFile, 'r').read())
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Perform assessment on data serialized by the Veritas LidarPerception module.')
+
+    parser.add_argument('--inputDir', type=str, help='Directory containing serialized data')
+    parser.add_argument('--veritasDir', type=str, help='Directory containing Veritas build directory')
+    parser.add_argument('--outputDir', type=str, help='Directory containing serialized data')
+    parser.add_argument('--plotLanes', help='Flag to plot lane segments', action='store_true')
+    parser.add_argument('--checkSpine', help='Flag to plot lane spine distances', action='store_true')
+    parser.add_argument('--verbose', help='Flag to display debug messages', action='store_true')
+    parser.add_argument('--upsample', help='The upsamle threshold. If this flag is not set, no upsample will be performed', required=False, type=float)
+
+    args = parser.parse_args()
+
+    sys.path.append(os.path.join(sys.path[0], args.veritasDir, 'build', 'DataSchemas', 'include', 'DataSchemas'))
+    from Flatbuffer.GroundTruth import Lanes, Lane, Vec3
+
+    inputDir = args.inputDir
+    outputDir = args.outputDir if args.outputDir else args.inputDir
+
+    inputFileLeft = os.path.join(inputDir, "lane-left.json")
+    inputFileRight = os.path.join(inputDir, "lane-right.json")
+    inputFileLeftValidities = os.path.join(inputDir, "lane-left-validities.json")
+    inputFileRightValidities = os.path.join(inputDir, "lane-right-validities.json")
+    inputFileLeftAnnotations = os.path.join(inputDir, "lane-left-annotations.json")
+    inputFileRightAnnotations = os.path.join(inputDir, "lane-right-annotations.json")
+    outputFile = os.path.join(outputDir, "lanes.fb")
+
+    laneSegments = getUpdatedSpine(inputFileLeft, inputFileRight, args.upsample, args.verbose)
+
+    left_validities = getDataFromJson(inputFileLeftValidities)
+    left_annotations = getDataFromJson(inputFileLeftAnnotations)
+    right_validities = getDataFromJson(inputFileRightValidities)
+    right_annotations = getDataFromJson(inputFileRightAnnotations)
+
+    builder = outputFlatbuffer(laneSegments, outputFile, left_validities, right_validities, left_annotations, right_annotations)
+    write_buffer(builder, outputFile)
+
+    if (args.checkSpine):
+        check_lane_spine(laneSegments)
+
+    if (args.plotLanes):
+        plotLines(laneSegments, args.verbose)

--- a/lambda/py/update_lanes.py
+++ b/lambda/py/update_lanes.py
@@ -117,7 +117,7 @@ def enumVector2VectorBuilderHelper(builder, numVals, nparray):
         builder.PrependByte(nparray[i])
     return builder.EndVector(numVals)
 
-def buildFlatbuffer(laneSegments, leftPointValidity, rightPointValidity, leftPointAnnotationStatus = [], rightPointAnnotationStatus = []):
+def buildFlatbuffer(laneSegments, leftPointValidity, rightPointValidity, leftPointAnnotationStatus, rightPointAnnotationStatus):
     temp_lanes = []
 
     for i in range(len(laneSegments)):
@@ -223,7 +223,7 @@ def getUpdatedSpine(input):
     name = input['name']
 
     laneSegments = getLinesFromJson(leftData, rightData, upsampleValue, verbose)
-    builder = buildFlatbuffer(laneSegments, input["leftPointValidity"], input["rightPointValidity"])
+    builder = buildFlatbuffer(laneSegments, input["leftPointValidity"], input["rightPointValidity"],input["leftPointAnnotationStatus"],input["rightPointAnnotationStatus"])
 
     create_original_lanes(region, bucket, name)
     write_buffer_to_s3(region, bucket, name, builder)

--- a/lambda/py/update_lanes.py
+++ b/lambda/py/update_lanes.py
@@ -117,7 +117,7 @@ def enumVector2VectorBuilderHelper(builder, numVals, nparray):
         builder.PrependByte(nparray[i])
     return builder.EndVector(numVals)
 
-def outputFlatbuffer(laneSegments, leftPointValidity, rightPointValidity, leftPointAnnotationStatus, rightPointAnnotationStatus):
+def buildFlatbuffer(laneSegments, leftPointValidity, rightPointValidity, leftPointAnnotationStatus = [], rightPointAnnotationStatus = []):
     temp_lanes = []
 
     for i in range(len(laneSegments)):
@@ -223,7 +223,7 @@ def getUpdatedSpine(input):
     name = input['name']
 
     laneSegments = getLinesFromJson(leftData, rightData, upsampleValue, verbose)
-    builder = outputFlatbuffer(laneSegments, input["leftPointValidity"], input["rightPointValidity"], ?, ?)
+    builder = buildFlatbuffer(laneSegments, input["leftPointValidity"], input["rightPointValidity"])
 
     create_original_lanes(region, bucket, name)
     write_buffer_to_s3(region, bucket, name, builder)
@@ -544,7 +544,7 @@ if __name__ == "__main__":
     right_validities = getDataFromJson(inputFileRightValidities)
     right_annotations = getDataFromJson(inputFileRightAnnotations)
 
-    builder = outputFlatbuffer(laneSegments, outputFile, left_validities, right_validities, left_annotations, right_annotations)
+    builder = buildFlatbuffer(laneSegments, outputFile, left_validities, right_validities, left_annotations, right_annotations)
     write_buffer(builder, outputFile)
 
     if (args.checkSpine):

--- a/lambda/py/update_lanes.py
+++ b/lambda/py/update_lanes.py
@@ -31,7 +31,7 @@ def create_original_lanes(region, bucket, name):
         }
         # write file
         s3.copy(copy_source, bucket, '/'.join([name, '2_Truth', 'original-lanes.fb']))
-    
+
 def write_buffer_to_s3(region, bucket, name, builder):
     output_data = builder.Output()
     size = len(output_data).to_bytes(4, byteorder='little', signed=True)
@@ -180,7 +180,7 @@ def buildFlatbuffer(laneSegments, leftPointValidity, rightPointValidity, leftPoi
         temp_lanes.append(lane)
 
         return builder
-        
+
 def getXYZ(data):
     x = data['position']['x']
     y = data['position']['y']
@@ -216,11 +216,13 @@ def getUpdatedSpine(inputFileLeft, inputFileRight, upsampleValue, verbose):
 def getUpdatedSpine(input):
     leftData = input['left']
     rightData = input['right']
-    upsampleValue = input['upsampleValue']
-    verbose = input['verbose']
     region = input["region"]
     bucket = input['bucket']
     name = input['name']
+
+    # safe access field that may not be passed
+    upsampleValue = input.get('upsampleValue')
+    verbose = input.get('verbose')
 
     laneSegments = getLinesFromJson(leftData, rightData, upsampleValue, verbose)
     builder = buildFlatbuffer(laneSegments, input["leftPointValidity"], input["rightPointValidity"],input["leftPointAnnotationStatus"],input["rightPointAnnotationStatus"])


### PR DESCRIPTION
The vast majority of code was restored from the original `lanes-to-fb`.   The 2 big differences between the 2 files is ...

1.  `lanes-to-fb` reads and writes to local files while Lambda version reads json input and writes to S3
2. The use of some flags/input data 
  * `upsampleValue`, `verbose` in the `lanes-to-fb`
  * `leftPointAnnotationStatus`, `rightPointAnnotationStatus` also in `lanes-to-fb`
 
The merged version can now run in both Lambda and locally.  

The high level changes ...

* When running locally, the `main` function is used and makes calls to an overloaded `getUpdatedSpine`: left and right data is loaded from local files and calls `getLinesFromJson` 

https://github.com/NextDroid/potree/blob/0afa1e14fbf611a8270cdbc688c2fd3b18a76ace/lambda/py/update_lanes.py#L540

https://github.com/NextDroid/potree/blob/0afa1e14fbf611a8270cdbc688c2fd3b18a76ace/lambda/py/update_lanes.py#L209

* When running from Lambda the `main` function is ignored and Lambda makes a direct call to the overloaded `getUpdatedSpine`: left and right data is passed in directly (along with bucket info).  Lambda version will now support `upsampleValue`  and `verbose` inputs via the input Json (`upsampleValue = input['upsampleValue']`, `verbose = input['verbose']`)

https://github.com/NextDroid/potree/blob/0afa1e14fbf611a8270cdbc688c2fd3b18a76ace/lambda/py/update_lanes.py#L216

* `getLinesFromJson` has been modified to simply return `laneSegments` rather than saving them to output.  Each context (local or Lambda) can then save appropriately

Local: https://github.com/NextDroid/potree/blob/0afa1e14fbf611a8270cdbc688c2fd3b18a76ace/lambda/py/update_lanes.py#L213
Lambda: https://github.com/NextDroid/potree/blob/0afa1e14fbf611a8270cdbc688c2fd3b18a76ace/lambda/py/update_lanes.py#L225

* `outputFlatBuffer` is renamed to `buildFlatBuffer` and simply returns the builder object which each context (local or Lambda) can then save appropriately.  

Local: https://github.com/NextDroid/potree/blob/0afa1e14fbf611a8270cdbc688c2fd3b18a76ace/lambda/py/update_lanes.py#L547

Lambda: https://github.com/NextDroid/potree/blob/0afa1e14fbf611a8270cdbc688c2fd3b18a76ace/lambda/py/update_lanes.py#L226
Lambda: 

* The Lambda version never supported `inputFileLeftAnnotations`/`inputFileRightAnnotations`.  These arrays default to empty in the Lambda context and so always create annotation statuses (maybe this is due to the POTree context :shrug: ).  Should this change?  If so then POTree would need to change so that it  passes in the status arrays.

https://github.com/NextDroid/potree/blob/0afa1e14fbf611a8270cdbc688c2fd3b18a76ace/lambda/py/update_lanes.py#L132