### PR TITLE
Added invalid lanes and lane selection tool

### DIFF
--- a/common/playbar.js
+++ b/common/playbar.js
@@ -227,6 +227,7 @@ export function createPlaybar () {
   document.getElementById("load_gaps_button").style.display = "none";
   document.getElementById("download_lanes_button").style.display = "none";
   document.getElementById("save_lanes_button").style.display = "none";
+  document.getElementById("select_lanes_button").style.display = "none";
 
   // original from radar.html
   document.getElementById("playbar_tmax").disabled = false;
@@ -234,7 +235,7 @@ export function createPlaybar () {
   document.getElementById("elevation_max").display = false;
   document.getElementById("elevation_min").disabled = false;
 
-  window.truthAnnotationMode = 0;	// 0: None, 1: Delete, 2: Add
+  window.truthAnnotationMode = 0;	// 0: None, 1: Delete, 2: Add, 3: Mark Invalid, 4: Mark Valid
   const annotationScreen = $(`<div id="annotationScreen"><p id="annotation-label">ANNOTATION MODE: <b id="annotation-mode-text"></b></p></div>`);
   $('body').prepend(annotationScreen);
   const div = document.getElementById("annotationScreen");
@@ -247,8 +248,12 @@ export function createPlaybar () {
         window.truthAnnotationMode = 2;
       } else if (e.code === "KeyS") {
         window.truthAnnotationMode = 1;
-      } else if (e.shiftKey) {
-        window.truthAnnotationMode = (window.truthAnnotationMode + 1) % 3;
+      } else if (e.code === "KeyI" && window.usingInvalidLanesSchema) {
+        window.truthAnnotationMode = 3;
+      } else if (e.code === "KeyV" && window.usingInvalidLanesSchema) {
+        window.truthAnnotationMode = 4;
+      }else if (e.shiftKey) {
+        window.truthAnnotationMode = (window.truthAnnotationMode + 1) % 5;
       }
 
       const div = document.getElementById("annotationScreen");
@@ -265,6 +270,14 @@ export function createPlaybar () {
         div.style.background = "green";
         div.style.opacity = 0.25;
         label.innerHTML = "ADD POINTS";
+      } else if (window.truthAnnotationMode === 3) {
+        div.style.background = "grey";
+        div.style.opacity = 0.25;
+        label.innerHTML = "MARK POINTS INVALID";
+      } else if (window.truthAnnotationMode === 4) {
+        div.style.background = "blue";
+        div.style.opacity = 0.2;
+        label.innerHTML = "MARK POINTS VALID";
       }
     }
   });
@@ -427,6 +440,7 @@ function saveLaneChanges () {
   if (laneLeftSegments === undefined) {
     const laneLeft = window.viewer.scene.scene.getChildByName("Lane Left");
     lane.left = laneLeft.points;
+    if (window.usingInvalidLanesSchema) lane.leftPointValidity = laneLeft.spheres.map(({validity}) => validity);
   } else {
     const polyline = laneLeftSegments.getFinalPoints();
     lane.left = polyline.points;
@@ -439,6 +453,7 @@ function saveLaneChanges () {
   if (laneRightSegments === undefined) {
     const laneRight = window.viewer.scene.scene.getChildByName("Lane Right");
     lane.right = laneRight.points;
+    if (window.usingInvalidLanesSchema) lane.rightPointValidity = laneRight.spheres.map(({validity}) => validity);;
   } else {
     const polyline = laneRightSegments.getFinalPoints();
     lane.right = polyline.points;

--- a/demo/LaneSegments.js
+++ b/demo/LaneSegments.js
@@ -44,9 +44,9 @@ export class LaneSegments extends THREE.Object3D {
     this.outAnnotations[this.outAnnotations.length-1].push({ pointAnnotation: pointAnnotation });
   };
 
-  addSegmentMarker(point) {
+  addSegmentMarker(point, validity) {
     // call addMarker for latest measure object
-    this.segments[this.segments.length-1].addMarker(point);
+    this.segments[this.segments.length-1].addMarker(point, null, validity);
   };
 
   getFinalPoints() {
@@ -65,7 +65,7 @@ export class LaneSegments extends THREE.Object3D {
       finalPoints = finalPoints.concat(this.segments[si].points);
       finalPoints = finalPoints.concat(this.outPoints[si+1]);
       // validities
-      const segmentValidities = Array(this.segments[si].points.length).fill(0);
+      const segmentValidities = window.usingInvalidLanesSchema ? this.segments[si].spheres.map(({validity}) => validity) : Array(this.segments[si].points.length).fill(0);
       finalPointValidities = finalPointValidities.concat(segmentValidities);
       outPointValidities = this.outValiditiesHelper(si+1);
       finalPointValidities = finalPointValidities.concat(outPointValidities);
@@ -98,7 +98,7 @@ export class LaneSegments extends THREE.Object3D {
     }
 
     if (newIsContains) {
-      this.addSegmentMarker(new THREE.Vector3(point.x(), point.y(), point.z()));
+      this.addSegmentMarker(new THREE.Vector3(point.x(), point.y(), point.z()), window.usingInvalidLanesSchema && pointValidity);
     } else {
       this.incrementOffset(new THREE.Vector3(point.x(), point.y(), point.z()), pointValidity, pointAnnotation);
     }

--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -641,8 +641,8 @@ export function addReloadLanesButton() {
     volume.addEventListener("mouseover", mouseover);
     volume.addEventListener("mouseleave", mouseleave);
 
-    let measurementsRoot = $("#jstree_scene").jstree().get_json("measurements");
-    let jsonNode = measurementsRoot.children.find(child => child.data.uuid === volume.uuid);
+    const measurementsRoot = $("#jstree_scene").jstree().get_json("measurements");
+    const jsonNode = measurementsRoot.children.find(child => child.data.uuid === volume.uuid);
     $.jstree.reference(jsonNode.id).deselect_all();
     $.jstree.reference(jsonNode.id).select_node(jsonNode.id);
   });

--- a/demo/radar.html
+++ b/demo/radar.html
@@ -127,7 +127,8 @@
 				  <button name="load_gaps_button" id="load_gaps_button">Load<br/>Gaps</button>
 				  <button name="load_radar_button" id="load_radar_button">Load<br/>Radar</button>
 				  <button name="download_lanes_button" id="download_lanes_button">Download<br/>Lanes</button>
-					<button name="save_lanes_button" id="save_lanes_button">Save<br/>Lanes</button>
+				  <button name="select_lanes_button" id="select_lanes_button">Select<br/>Lanes</button>
+				  <button name="save_lanes_button" id="save_lanes_button">Save<br/>Lanes</button>
 				  <button name="reload_lanes_button" id="reload_lanes_button">Annotate<br/>Lanes</button>
 				  <button name="annotate_tracks_button" id="annotate_tracks_button">Annotate<br/>Tracks</button>
 				</div>

--- a/src/utils/Measure.js
+++ b/src/utils/Measure.js
@@ -212,7 +212,7 @@ export class Measure extends THREE.Object3D {
 						}
 					});
 				} else if (window.truthAnnotationMode == 3 && window.usingInvalidLanesSchema) {
-					let i = this.spheres.indexOf(e.target);
+					const i = this.spheres.indexOf(e.target);
 					if (i != -1) {
 						this.spheres[i].validity = 1;
 						this.update();
@@ -220,7 +220,7 @@ export class Measure extends THREE.Object3D {
 						console.error("Clicked sphere not in list of spheres: ", e);
 					}
 				} else if (window.truthAnnotationMode == 4 && window.usingInvalidLanesSchema) {
-					let i = this.spheres.indexOf(e.target);
+					const i = this.spheres.indexOf(e.target);
 					if (i != -1) {
 						this.spheres[i].validity = 0;
 						this.update();

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -1550,7 +1550,7 @@ export class Viewer extends EventDispatcher{
 
 			// volumes with clipping enabled
 			//boxes.push(...this.scene.volumes.filter(v => (v.clip)));
-			boxes.push(...this.scene.volumes.filter(v => (v.clip && v instanceof BoxVolume)));
+			boxes.push(...this.scene.volumes.filter(v => (v.clip && v instanceof BoxVolume || v.clip && v.name === 'selected_lanes')));
 
 			// profile segments
 			for(let profile of this.scene.profiles){


### PR DESCRIPTION
This PR has quite a few things going on, but they're all in one PR because each of these things don't work without the other:
- Invalid lanes tool adds the ability to mark lane nodes as "invalid" with the "I" key and "valid" with the "V" key. Valid lanes are normal lanes, invalid lanes will be moved to a new layer called "Invalid Lanes" when the lanes are saved. This lane layer is invisible by default, and shows up darker than valid lanes when turned on
- Compatibility for the new validity/anomaly schema. This got a little messy because leftPointValidity/rightPointValidity was used for anomalies in the old schema, but it's used for lane validity in the new schema, and there's a new field for anomalies. I tried to keep it clean, but there is a global "window.usingInvalidLaneSchemas" to keep track of this
- Removed "annotated-lanes.fb" and replaced with "lanes.fb" again
- New lane selection tool. Allows a volume to be placed, and nodes in that volume can be deleted or marked invalid/valid all at once