### PR TITLE
Removed duplicate lanes in sidebar

### DIFF
--- a/common/custom-sidebar.js
+++ b/common/custom-sidebar.js
@@ -85,6 +85,21 @@ export function updateSidebar(vizConfiguration) {
 	};
   window.viewer.scene.addEventListener("truth_layer_added", onTruthLayerAdded);
 
+  const onTruthLayerDeleted = (e) => {
+    const truthNodes = tree.jstree("get_children_dom", truthVizTree);
+    let nodeID;
+    for (let i = 0; i < truthNodes.length; i++) {
+      if (truthNodes[i].textContent === e.truthLayer.name) {
+        nodeID = truthNodes[i].id;
+        break;
+      }
+    }
+
+    if (nodeID) {
+      tree.jstree('delete_node', nodeID);
+    }
+  };
+  window.viewer.scene.addEventListener("truth_layer_deleted", onTruthLayerDeleted)
 
   const sensorTree = tree.jstree('create_node', "#", { "text": "<b>Sensor Readings</b>", "id": "sensorViz"}, "last", false, false);
   tree.jstree("check_node", sensorTree);

--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -508,12 +508,20 @@ export function addReloadLanesButton() {
       let removeLanes = viewer.scene.scene.getChildByName("Lanes");
       while (removeLanes) {
         viewer.scene.scene.remove(removeLanes);
+        viewer.scene.dispatchEvent({
+          "type": "truth_layer_deleted",
+          "truthLayer": removeLanes
+        });
         removeLanes = viewer.scene.scene.getChildByName("Lanes");
         // TODO remove "Lanes" from sidebar
       }
       let removeInvalidLanes = viewer.scene.scene.getChildByName("Invalid Lanes");
       while (removeInvalidLanes) {
         viewer.scene.scene.remove(removeInvalidLanes);
+        viewer.scene.dispatchEvent({
+          "type": "truth_layer_deleted",
+          "truthLayer": removeInvalidLanes
+        });
         removeInvalidLanes = viewer.scene.scene.getChildByName("Invalid Lanes");
         // TODO remove "Lanes" from sidebar
       }


### PR DESCRIPTION
When reloading lanes for annotations, the old lanes would still appear in the sidebar, though the data would be deleted. So checking/unchecking the node basically did nothing. This PR removes those nodes.





