### PR TITLE
Correct lane segments marked invalid

### DIFF
--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -244,7 +244,7 @@ async function createLaneGeometries (lanes, supplierNum, annotationMode, volumes
 
         boxGeometry.applyMatrix( se3 );
         // TODO rotate boxGeometry.quaternion.setFromUnitVectors(axis, vector.clone().normalize());
-        if (validities && validities[ii - 1] && validities[ii]) {
+        if (validities && (validities[ii - 1] || validities[ii])) {
           invalidBoxes.merge(boxGeometry);
         }
         else {


### PR DESCRIPTION
This'll have the correct lane segments marked as invalid. Rather than the points working in "pairs", both segments surrounding a point will now be invalid.



