### PR TITLE
Added ability to load lanes through console

### DIFF
--- a/demo/loaderHelper.js
+++ b/demo/loaderHelper.js
@@ -20,7 +20,7 @@ import { addLoadGapsButton, gapDownloads } from "../demo/gapsLoader.js"
 import { addLoadRadarButton, radarDownloads } from "../demo/radarLoader.js"
 import { addDetectionButton, detectionDownloads } from "../demo/detectionLoader.js"
 import { PointAttributeNames } from "../src/loader/PointAttributes.js";
-import { setNumTasks } from "../common/overlay.js"
+import { resetProgressBars, setNumTasks } from "../common/overlay.js"
 import { loadControlPointsCallback } from "../demo/controlPointLoader.js"
 import { getFiles } from "../demo/loaderUtilities.js"
 
@@ -179,6 +179,18 @@ async function loadDataIntoDocument(filesTable) {
 			window.canEnableCalibrationPanels = false;
 			window.disableReason = "Do not have necessary calibration files to use calibration panels";
 		}
+
+
+		window.loadAdditionalLanes = async function (bucket, dataset, version, filename) {
+			const datasetPath = "Data/" + dataset + "¶" + version.toString().padStart(3, '0');
+
+			try {
+				resetProgressBars();
+				await loadLanesCallback(s3, bucket, datasetPath, filename);
+			} catch (e) {
+				console.error("Could not load Lanes: ", e);
+			}
+		};
 
 		// Load Lanes:
 		try {


### PR DESCRIPTION
Adds the ability to load additional lanes through the console.
The command is `window.loadAdditionalLanes(bucket, dataset, version, filename)`
For example: `window.loadAdditionalLanes("veritas-test-2019-07-02", "SPP_test_GJ_F3_SLICE_640_740", 32, "lanes.fb")`

Argument names for some of these functions suck (fname, name, etc.). I plan on fixing that sort of thing when I start the full potree clean up