### PR TITLE
Removed optional chaining

### DIFF
--- a/src/viewer/sidebar.js
+++ b/src/viewer/sidebar.js
@@ -437,10 +437,12 @@ export class Sidebar{
 			const object = data.node.data;
 
 			const uncheckChildren = (node) => {
-				node?.children?.forEach(child => {
-					tree.jstree("uncheck_node", child);
-					uncheckChildren(child.children);
-				});
+				if (node && node.children) {
+					node.children.forEach(child => {
+						tree.jstree("uncheck_node", child);
+						uncheckChildren(child.children);
+					});
+				}
 			}
 			uncheckChildren(data.node);
 


### PR DESCRIPTION
Optional chaining is not supported by the node.js version in our potree server, so I had to remove it.




