### PR TITLE
Hide invalid and anomalous truth from customers

### DIFF
--- a/demo/laneLoader.js
+++ b/demo/laneLoader.js
@@ -470,7 +470,7 @@ function addLaneGeometries (laneGeometries, lanesLayer, invalidLanesLayer) {
 
   viewer.scene.scene.add(lanesLayer);
 
-  if (invalidLanesLayer.children.length > 0) {
+  if (invalidLanesLayer.children.length > 0 && annotateAvailable) {
     viewer.scene.scene.add(invalidLanesLayer);
 
     viewer.scene.dispatchEvent({

--- a/demo/trackLoader.js
+++ b/demo/trackLoader.js
@@ -3,6 +3,7 @@
 // import { Flatbuffer } from "http://localhost:1234/schemas/GroundTruth_generated.js";
 import { updateLoadingBar, incrementLoadingBarTotal } from "../common/overlay.js";
 import { getFbFileInfo, removeFileExtension, indexOfClosestTimestamp } from "./loaderUtilities.js";
+import { annotateAvailable } from "./paramLoader.js";
 
 
 // sets local variable and returns so # files can be counted
@@ -384,7 +385,7 @@ async function loadTracksCallbackHelper (s3, bucket, name, trackShaderMaterial, 
 			"truthLayer": trackLayer
     });
 
-    if (anomalousTrackInfo.length > 0) {
+    if (anomalousTrackInfo.length > 0 && annotateAvailable) {
       viewer.scene.scene.add(anomalousTrackLayer);
       const e = new CustomEvent("truth_layer_added", { detail: anomalousTrackLayer, writable: true });
       viewer.scene.dispatchEvent({


### PR DESCRIPTION
Hides invalid lanes and anomalous tracks from non-annotators.





