### PR TITLE
Added split anomaly layers

### DIFF
--- a/src/viewer/sidebar.js
+++ b/src/viewer/sidebar.js
@@ -436,15 +436,17 @@ export class Sidebar{
 		tree.on("uncheck_node.jstree", (e, data) => {
 			const object = data.node.data;
 
-			const uncheckChildren = (node) => {
-				if (node && node.children) {
-					node.children.forEach(child => {
-						tree.jstree("uncheck_node", child);
-						uncheckChildren(child.children);
-					});
+			if (data.node.id !== annotationsID && !data.node.parents.includes(annotationsID)) {
+				const uncheckChildren = (node) => {
+					if (node && node.children) {
+						node.children.forEach(child => {
+							tree.jstree("uncheck_node", child);
+							uncheckChildren(child.children);
+						});
+					}
 				}
+				uncheckChildren(data.node);
 			}
-			uncheckChildren(data.node);
 
 			if(object){
 				object.visible = false;
@@ -454,15 +456,17 @@ export class Sidebar{
 		tree.on("check_node.jstree", (e, data) => {
 			const object = data.node.data;
 
-			const checkChildren = (node) => {
-				if (node && node.children) {
-					node.children.forEach(child => {
-						tree.jstree("check_node", child);
-						checkChildren(child.children);
-					});
+			if (data.node.id !== annotationsID && !data.node.parents.includes(annotationsID)) {
+				const checkChildren = (node) => {
+					if (node && node.children) {
+						node.children.forEach(child => {
+							tree.jstree("check_node", child);
+							checkChildren(child.children);
+						});
+					}
 				}
+				checkChildren(data.node);
 			}
-			checkChildren(data.node);
 
 			if(object){
 				object.visible = true;


### PR DESCRIPTION
If a dataset has more than the maximum number of annotations per layer (500 right now), its anomalies will be split into multiple layers. Datasets with fewer annotations will function exactly the same as before.

Normally, when something in the sidebar is checked/unchecked, its children will also be checked/unchecked. I disabled this for annotations, otherwise we would get the same lag as before since every annotation layer would get selected.