### PR TITLE
Measurements and lanes can be dragged to red lidar scans

### DIFF
--- a/src/PointCloudOctree.js
+++ b/src/PointCloudOctree.js
@@ -704,7 +704,8 @@ export class PointCloudOctree extends PointCloudTree {
 		{ // RENDER
 			renderer.setRenderTarget(pickState.renderTarget);
 			gl.clearColor(0, 0, 0, 0);
-			renderer.clearTarget( pickState.renderTarget, true, true, true );
+			renderer.setRenderTarget(pickState.renderTarget);
+			renderer.clear(true, true, true);
 
 			let tmp = this.material;
 			this.material = pickMaterial;

--- a/src/materials/shaders/pointcloud.vs
+++ b/src/materials/shaders/pointcloud.vs
@@ -732,6 +732,17 @@ vec3 getColor(vec4 correctedPosition){
 		color = getConfidence();
 	#endif
 
+	#if defined(clip_gps_enabled) && !defined(color_type_point_index)
+		float time = gpsTime + uGPSOffset;
+		vec2 range = uFilterGPSTimeClipRange;
+
+		if (!uExtrinsicsMode && time > range.x && time < range.y && uVisualizeTimeRange) { // favor this first
+			color.r = 1.0;
+			color.b = 0.0;
+			color.g = 0.0;
+		}
+	#endif
+
 	return color;
 }
 
@@ -863,12 +874,7 @@ void doClipping(vec4 correctedPosition){
 		//}
 
 		if (!uExtrinsicsMode) {
-			if (time > range.x && time < range.y && uVisualizeTimeRange) { // favor this first
-				vColor.r = 1.0;
-				vColor.b = 0.0;
-				vColor.g = 0.0;
-			}
-			else if (classification == 3.0) { // then, for non road class outside of the window
+			if (!(time > range.x && time < range.y && uVisualizeTimeRange) && classification == 3.0) {
 				gl_Position = vec4(100.0, 100.0, 100.0, 0.0);
 			}
 		} else {


### PR DESCRIPTION
This change allows measurements points and lane annotation points to be placed/dragged on red points in the pointcloud. I also moved the code in the shader that colors red points to the `getColor` function. This wasn't totally necessary, but made sense to me.

I also snuck in a fix to an annoying warning we get. `renderer.clear(...)` is deprecated, so I updated that line.





