### PR TITLE
Classifications now work in composite view

### DIFF
--- a/src/materials/shaders/pointcloud.vs
+++ b/src/materials/shaders/pointcloud.vs
@@ -828,15 +828,13 @@ bool pointInClipPolygon(vec3 point, int polyIdx) {
 
 void doClipping(vec4 correctedPosition){
 
-	#if !defined color_type_composite
-		vec4 cl = getClassification();
-		if(cl.a == 0.0){
-			gl_Position = vec4(100.0, 100.0, 100.0, 0.0);
-			vColor.r += 0.85;
+	vec4 cl = getClassification();
+	if(cl.a == 0.0){
+		gl_Position = vec4(100.0, 100.0, 100.0, 0.0);
+		vColor.r += 0.85;
 
-			return;
-		}
-	#endif
+		return;
+	}
 
 	#if defined(clip_return_number_enabled)
 	{ // return number filter


### PR DESCRIPTION
I'm not sure why classifications were disabled in composite view (road, non-road, etc.), but Joe wanted me to enable them so I did.





